### PR TITLE
Merged xTimeZone and converted to HQRM - Fixes #157

### DIFF
--- a/.vscode/RunAllTests.ps1
+++ b/.vscode/RunAllTests.ps1
@@ -1,11 +1,12 @@
-[string] $repoRoot = Split-Path -Path (Split-Path -Path $Script:MyInvocation.MyCommand.Path)
-if ( (-not (Test-Path -Path (Join-Path -Path $repoRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $repoRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+$repoRoot = Split-Path -Path (Split-Path -Path $Script:MyInvocation.MyCommand.Path)
+$dscResourceTestsPath = Join-Path -Path $repoRoot -ChildPath '\Modules\ComputerManagementDsc\DSCResource.Tests\'
+
+if ((-not (Test-Path -Path $dscResourceTestsPath)) -or `
+    (-not (Test-Path -Path (Join-Path -Path $dscResourceTestsPath -ChildPath 'TestHelper.psm1'))))
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $repoRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', $dscResourceTestsPath)
 }
 
-Import-Module (Join-Path $PSScriptRoot "..\Tests\TestHarness.psm1" -Resolve)
-$dscTestsPath = Join-Path -Path $PSScriptRoot `
-                          -ChildPath "..\Modules\ComputerManagementDsc\DscResource.Tests\Meta.Tests.ps1"
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\Tests\TestHarness.psm1' -Resolve)
+$dscTestsPath = Join-Path -Path $dscResourceTestsPath -ChildPath 'Meta.Tests.ps1'
 Invoke-TestHarness -DscTestsPath $dscTestsPath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - TimeZone:
   - Migrated xTimeZone resource from [xTimeZone](https://github.com/PowerShell/xTimeZone)
     and renamed to TimeZone - fixes [Issue #157](https://github.com/PowerShell/ComputerManagementDsc/issues/157).
+- Moved Test-Command from ComputerManagementDsc.ResourceHelper to
+  ComputerManagementDsc.Common module to match what TimeZone requires.
+  It was not exported in ComputerManagementDsc.ResourceHelper and not
+  used.
 
 ## 5.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- TimeZone:
+  - Migrated xTimeZone resource from [xTimeZone](https://github.com/PowerShell/xTimeZone)
+    and renamed to TimeZone - fixes [Issue #157](https://github.com/PowerShell/ComputerManagementDsc/issues/157).
+
 ## 5.0.0.0
 
 - BREAKING CHANGE:

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/MSFT_TimeZone.psm1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/MSFT_TimeZone.psm1
@@ -1,0 +1,131 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
+# Import the ComputerManagementDsc Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+        -ChildPath (Join-Path -Path 'ComputerManagementDsc.Common' `
+            -ChildPath 'ComputerManagementDsc.Common.psm1'))
+
+# Import the ComputerManagementDsc Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+        -ChildPath (Join-Path -Path 'ComputerManagementDsc.ResourceHelper' `
+            -ChildPath 'ComputerManagementDsc.ResourceHelper.psm1'))
+
+# Import Localization Strings.
+$LocalizedData = Get-LocalizedData `
+    -ResourceName 'MSFT_TimeZone' `
+    -ResourcePath (Split-Path -Parent $script:MyInvocation.MyCommand.Path)
+
+<#
+    .SYNOPSIS
+    Returns the current time zone of the node.
+
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+
+    .PARAMETER TimeZone
+    Specifies the time zone.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $TimeZone
+    )
+
+    Write-Verbose -Message ($LocalizedData.GettingTimeZoneMessage)
+
+    # Get the current time zone Id.
+    $currentTimeZone = Get-TimeZoneId
+
+    $returnValue = @{
+        IsSingleInstance = 'Yes'
+        TimeZone         = $currentTimeZone
+    }
+
+    # Output the target resource.
+    return $returnValue
+}
+
+<#
+    .SYNOPSIS
+    Sets the current time zone of the node.
+
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+
+    .PARAMETER TimeZone
+    Specifies the time zone.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $TimeZone
+    )
+
+    $currentTimeZone = Get-TimeZoneId
+
+    if ($currentTimeZone -ne $TimeZone)
+    {
+        Write-Verbose -Message ($LocalizedData.SettingTimeZoneMessage)
+        Set-TimeZoneId -TimeZone $TimeZone
+    }
+    else
+    {
+        Write-Verbose -Message ($LocalizedData.TimeZoneAlreadySetMessage `
+                -f $TimeZone)
+    }
+}
+
+<#
+    .SYNOPSIS
+    Tests the current time zone of the node.
+
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+
+    .PARAMETER TimeZone
+    Specifies the time zone.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $TimeZone
+    )
+
+    Write-Verbose -Message ($LocalizedData.TestingTimeZoneMessage)
+
+    return Test-TimeZoneId -TimeZoneId $TimeZone
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/MSFT_TimeZone.schema.mof
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/MSFT_TimeZone.schema.mof
@@ -1,0 +1,6 @@
+[ClassVersion("1.0.0.0"), FriendlyName("TimeZone")]
+class MSFT_TimeZone : OMI_BaseResource
+{
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
+    [Required, Description("Specifies the TimeZone.")] String TimeZone;
+};

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/README.md
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/README.md
@@ -1,0 +1,7 @@
+# Description
+
+The resource will use the `Get-TimeZone` cmdlet to get the current
+time zone. If `Get-TimeZone` is not available them CIM will be used to retrieve
+the current time zone. To update the time zone, .NET reflection will be used to
+update the time zone if required. If .NET reflection is not supported on the node
+(in the case of Nano Server) then tzutil.exe will be used to set the time zone.

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/en-us/MSFT_TimeZone.strings.psd1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_TimeZone/en-us/MSFT_TimeZone.strings.psd1
@@ -1,0 +1,8 @@
+# culture="en-US"
+ConvertFrom-StringData -StringData @'
+    GettingTimeZoneMessage       = Getting the time zone.
+    ReplaceSystemTimeZoneMessage = Replace the System time zone.
+    SettingTimeZoneMessage       = Setting the time zone.
+    TimeZoneAlreadySetMessage    = Time zone already set to {0}.
+    TestingTimeZoneMessage       = Testing the time zone.
+'@

--- a/Modules/ComputerManagementDsc/Examples/Resources/TimeZone/1-SetTimeZone.ps1
+++ b/Modules/ComputerManagementDsc/Examples/Resources/TimeZone/1-SetTimeZone.ps1
@@ -1,0 +1,25 @@
+<#
+    .EXAMPLE
+        This example sets the current time zone on the node
+        to 'Tonga Standard Time'.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DSCResource -ModuleName ComputerManagementDsc
+
+    Node $NodeName
+    {
+        TimeZone TimeZoneExample
+        {
+            IsSingleInstance = 'Yes'
+            TimeZone         = 'Tonga Standard Time'
+        }
+    }
+}

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
@@ -310,6 +310,155 @@ function Test-DscObjectHasProperty
     return $false
 }
 
+<#
+    .SYNOPSIS
+        Get the of the current time zone Id.
+#>
+function Get-TimeZoneId
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    if (Test-Command -Name 'Get-TimeZone' -Module 'Microsoft.PowerShell.Management')
+    {
+        Write-Verbose -Message ($LocalizedData.GettingTimeZoneMessage -f 'Cmdlets')
+
+        $timeZone = (Get-TimeZone).StandardName
+    }
+    else
+    {
+        Write-Verbose -Message ($LocalizedData.GettingTimeZoneMessage -f 'CIM')
+
+        $timeZone = (Get-CimInstance `
+                -ClassName Win32_TimeZone `
+                -Namespace root\cimv2).StandardName
+    }
+
+    Write-Verbose -Message ($LocalizedData.CurrentTimeZoneMessage `
+            -f $timeZone)
+
+    $timeZoneInfo = [System.TimeZoneInfo]::GetSystemTimeZones() |
+        Where-Object StandardName -eq $timeZone
+
+    return $timeZoneInfo.Id
+} # function Get-TimeZoneId
+
+<#
+    .SYNOPSIS
+        Compare a time zone Id with the current time zone Id.
+
+    .PARAMETER TimeZoneId
+        The Id of the time zone to compare with the current time zone.
+#>
+function Test-TimeZoneId
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $TimeZoneId
+    )
+
+    # Test if the expected value is the same as the current value.
+    $currentTimeZoneId = Get-TimeZoneId
+
+    return $TimeZoneId -eq $currentTimeZoneId
+} # function Test-TimeZoneId
+
+<#
+    .SYNOPSIS
+        Sets the current time zone using a time zone Id.
+
+    .PARAMETER TimeZoneId
+        The Id of the time zone to set.
+#>
+function Set-TimeZoneId
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $TimeZoneId
+    )
+
+    if (Test-Command -Name 'Set-TimeZone' -Module 'Microsoft.PowerShell.Management')
+    {
+        Set-TimeZone -Id $TimeZoneId
+    }
+    else
+    {
+        if (Test-Command -Name 'Add-Type' -Module 'Microsoft.Powershell.Utility')
+        {
+            # We can use reflection to modify the time zone.
+            Write-Verbose -Message ($LocalizedData.SettingTimeZoneMessage `
+                    -f $TimeZoneId, '.NET')
+
+            Set-TimeZoneUsingDotNet -TimeZoneId $TimeZoneId
+        }
+        else
+        {
+            # For anything else use TZUTIL.EXE.
+            Write-Verbose -Message ($LocalizedData.SettingTimeZoneMessage `
+                    -f $TimeZoneId, 'TZUTIL.EXE')
+
+            try
+            {
+                & tzutil.exe @('/s', $TimeZoneId)
+            }
+            catch
+            {
+                Write-Verbose -Message $_.Exception.Message
+            } # try
+        } # if
+    } # if
+
+    Write-Verbose -Message ($LocalizedData.TimeZoneUpdatedMessage `
+            -f $TimeZoneId)
+} # function Set-TimeZoneId
+
+<#
+    .SYNOPSIS
+        This function sets the time zone on the machine using .NET reflection.
+        It exists so that the ::Set method can be mocked by Pester.
+
+    .PARAMETER TimeZoneId
+        The Id of the time zone to set using .NET.
+#>
+function Set-TimeZoneUsingDotNet
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $TimeZoneId
+    )
+
+    # Add the [TimeZoneHelper.TimeZone] type if it is not defined.
+    if (-not ([System.Management.Automation.PSTypeName] 'TimeZoneHelper.TimeZone').Type)
+    {
+        Write-Verbose -Message ($LocalizedData.AddingSetTimeZoneDotNetTypeMessage)
+
+        $setTimeZoneCs = Get-Content `
+            -Path (Join-Path -Path $PSScriptRoot -ChildPath 'SetTimeZone.cs') `
+            -Raw
+
+        Add-Type `
+            -Language CSharp `
+            -TypeDefinition $setTimeZoneCs
+    } # if
+
+    [Microsoft.PowerShell.TimeZone.TimeZone]::Set($TimeZoneId)
+} # function Set-TimeZoneUsingDotNet
+
 Export-ModuleMember -Function `
     Test-DscParameterState, `
-    Test-DscObjectHasProperty
+    Test-DscObjectHasProperty, `
+    Get-TimeZoneId, `
+    Test-TimeZoneId, `
+    Set-TimeZoneId, `
+    Set-TimeZoneUsingDotNet

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
@@ -1,4 +1,4 @@
-# Import the Networking Resource Helper Module
+# Import the ComputerManagement Resource Helper Module
 Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
         -ChildPath (Join-Path -Path 'ComputerManagementDsc.ResourceHelper' `
             -ChildPath 'ComputerManagementDsc.ResourceHelper.psm1'))

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
@@ -312,6 +312,34 @@ function Test-DscObjectHasProperty
 
 <#
     .SYNOPSIS
+        This function tests if a cmdlet exists.
+
+    .PARAMETER Name
+        The name of the cmdlet to check for.
+
+    .PARAMETER Module
+        The module containing the command.
+#>
+function Test-Command
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Module
+    )
+
+    return ($null -ne (Get-Command @PSBoundParameters -ErrorAction SilentlyContinue))
+} # function Test-Command
+
+<#
+    .SYNOPSIS
         Get the of the current time zone Id.
 #>
 function Get-TimeZoneId
@@ -458,6 +486,7 @@ function Set-TimeZoneUsingDotNet
 Export-ModuleMember -Function `
     Test-DscParameterState, `
     Test-DscObjectHasProperty, `
+    Test-Command, `
     Get-TimeZoneId, `
     Test-TimeZoneId, `
     Set-TimeZoneId, `

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/ComputerManagementDsc.Common.psm1
@@ -364,11 +364,10 @@ function Get-TimeZoneId
                 -Namespace root\cimv2).StandardName
     }
 
-    Write-Verbose -Message ($LocalizedData.CurrentTimeZoneMessage `
-            -f $timeZone)
+    Write-Verbose -Message ($LocalizedData.CurrentTimeZoneMessage -f $timeZone)
 
     $timeZoneInfo = [System.TimeZoneInfo]::GetSystemTimeZones() |
-        Where-Object StandardName -eq $timeZone
+        Where-Object -Property StandardName -EQ $timeZone
 
     return $timeZoneInfo.Id
 } # function Get-TimeZoneId
@@ -422,16 +421,14 @@ function Set-TimeZoneId
         if (Test-Command -Name 'Add-Type' -Module 'Microsoft.Powershell.Utility')
         {
             # We can use reflection to modify the time zone.
-            Write-Verbose -Message ($LocalizedData.SettingTimeZoneMessage `
-                    -f $TimeZoneId, '.NET')
+            Write-Verbose -Message ($LocalizedData.SettingTimeZoneMessage -f $TimeZoneId, '.NET')
 
             Set-TimeZoneUsingDotNet -TimeZoneId $TimeZoneId
         }
         else
         {
             # For anything else use TZUTIL.EXE.
-            Write-Verbose -Message ($LocalizedData.SettingTimeZoneMessage `
-                    -f $TimeZoneId, 'TZUTIL.EXE')
+            Write-Verbose -Message ($LocalizedData.SettingTimeZoneMessage -f $TimeZoneId, 'TZUTIL.EXE')
 
             try
             {
@@ -444,8 +441,7 @@ function Set-TimeZoneId
         } # if
     } # if
 
-    Write-Verbose -Message ($LocalizedData.TimeZoneUpdatedMessage `
-            -f $TimeZoneId)
+    Write-Verbose -Message ($LocalizedData.TimeZoneUpdatedMessage -f $TimeZoneId)
 } # function Set-TimeZoneId
 
 <#

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/SetTimeZone.cs
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/SetTimeZone.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Security;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
+namespace Microsoft.PowerShell.TimeZone
+{
+    [StructLayoutAttribute(LayoutKind.Sequential)]
+    public struct SystemTime
+    {
+        [MarshalAs(UnmanagedType.U2)]
+        public short Year;
+        [MarshalAs(UnmanagedType.U2)]
+        public short Month;
+        [MarshalAs(UnmanagedType.U2)]
+        public short DayOfWeek;
+        [MarshalAs(UnmanagedType.U2)]
+        public short Day;
+        [MarshalAs(UnmanagedType.U2)]
+        public short Hour;
+        [MarshalAs(UnmanagedType.U2)]
+        public short Minute;
+        [MarshalAs(UnmanagedType.U2)]
+        public short Second;
+        [MarshalAs(UnmanagedType.U2)]
+        public short Milliseconds;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct TimeZoneInformation
+    {
+        [MarshalAs(UnmanagedType.I4)]
+        public int Bias;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        public string StandardName;
+        public SystemTime StandardDate;
+        [MarshalAs(UnmanagedType.I4)]
+        public int StandardBias;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+        public string DaylightName;
+        public SystemTime DaylightDate;
+        [MarshalAs(UnmanagedType.I4)]
+        public int DaylightBias;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct DynamicTimeZoneInformation
+    {
+        public int Bias;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string StandardName;
+        public SystemTime StandardDate;
+        public int StandardBias;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string DaylightName;
+        public SystemTime DaylightDate;
+        public int DaylightBias;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string TimeZoneKeyName;
+        [MarshalAs(UnmanagedType.U1)]
+        public bool DynamicDaylightTimeDisabled;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RegistryTimeZoneInformation
+    {
+        [MarshalAs(UnmanagedType.I4)]
+        public int Bias;
+        [MarshalAs(UnmanagedType.I4)]
+        public int StandardBias;
+        [MarshalAs(UnmanagedType.I4)]
+        public int DaylightBias;
+        public SystemTime StandardDate;
+        public SystemTime DaylightDate;
+        public RegistryTimeZoneInformation(TimeZoneInformation tzi)
+        {
+            this.Bias = tzi.Bias;
+            this.StandardDate = tzi.StandardDate;
+            this.StandardBias = tzi.StandardBias;
+            this.DaylightDate = tzi.DaylightDate;
+            this.DaylightBias = tzi.DaylightBias;
+        }
+        public RegistryTimeZoneInformation(byte[] bytes)
+        {
+            if ((bytes == null) || (bytes.Length != 0x2c))
+            {
+                throw new ArgumentException("Argument_InvalidREG_TZI_FORMAT");
+            }
+            this.Bias = BitConverter.ToInt32(bytes, 0);
+            this.StandardBias = BitConverter.ToInt32(bytes, 4);
+            this.DaylightBias = BitConverter.ToInt32(bytes, 8);
+            this.StandardDate.Year = BitConverter.ToInt16(bytes, 12);
+            this.StandardDate.Month = BitConverter.ToInt16(bytes, 14);
+            this.StandardDate.DayOfWeek = BitConverter.ToInt16(bytes, 0x10);
+            this.StandardDate.Day = BitConverter.ToInt16(bytes, 0x12);
+            this.StandardDate.Hour = BitConverter.ToInt16(bytes, 20);
+            this.StandardDate.Minute = BitConverter.ToInt16(bytes, 0x16);
+            this.StandardDate.Second = BitConverter.ToInt16(bytes, 0x18);
+            this.StandardDate.Milliseconds = BitConverter.ToInt16(bytes, 0x1a);
+            this.DaylightDate.Year = BitConverter.ToInt16(bytes, 0x1c);
+            this.DaylightDate.Month = BitConverter.ToInt16(bytes, 30);
+            this.DaylightDate.DayOfWeek = BitConverter.ToInt16(bytes, 0x20);
+            this.DaylightDate.Day = BitConverter.ToInt16(bytes, 0x22);
+            this.DaylightDate.Hour = BitConverter.ToInt16(bytes, 0x24);
+            this.DaylightDate.Minute = BitConverter.ToInt16(bytes, 0x26);
+            this.DaylightDate.Second = BitConverter.ToInt16(bytes, 40);
+            this.DaylightDate.Milliseconds = BitConverter.ToInt16(bytes, 0x2a);
+        }
+    }
+    public class TokenPrivilegesAccess
+    {
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto)]
+        public static extern int OpenProcessToken(int ProcessHandle, int DesiredAccess,
+        ref int tokenhandle);
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        public static extern int GetCurrentProcess();
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto)]
+        public static extern int LookupPrivilegeValue(string lpsystemname, string lpname,
+        [MarshalAs(UnmanagedType.Struct)] ref LUID lpLuid);
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto)]
+        public static extern int AdjustTokenPrivileges(int tokenhandle, int disableprivs,
+            [MarshalAs(UnmanagedType.Struct)]ref TOKEN_PRIVILEGE Newstate, int bufferlength,
+            int PreivousState, int Returnlength);
+        public const int TOKEN_ASSIGN_PRIMARY = 0x00000001;
+        public const int TOKEN_DUPLICATE = 0x00000002;
+        public const int TOKEN_IMPERSONATE = 0x00000004;
+        public const int TOKEN_QUERY = 0x00000008;
+        public const int TOKEN_QUERY_SOURCE = 0x00000010;
+        public const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
+        public const int TOKEN_ADJUST_GROUPS = 0x00000040;
+        public const int TOKEN_ADJUST_DEFAULT = 0x00000080;
+        public const UInt32 SE_PRIVILEGE_ENABLED_BY_DEFAULT = 0x00000001;
+        public const UInt32 SE_PRIVILEGE_ENABLED = 0x00000002;
+        public const UInt32 SE_PRIVILEGE_REMOVED = 0x00000004;
+        public const UInt32 SE_PRIVILEGE_USED_FOR_ACCESS = 0x80000000;
+        public static bool EnablePrivilege(string privilege)
+        {
+            try
+            {
+                int token = 0;
+                int retVal = 0;
+                TOKEN_PRIVILEGE TP = new TOKEN_PRIVILEGE();
+                LUID LD = new LUID();
+                retVal = OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref token);
+                retVal = LookupPrivilegeValue(null, privilege, ref LD);
+                TP.PrivilegeCount = 1;
+                var luidAndAtt = new LUID_AND_ATTRIBUTES();
+                luidAndAtt.Attributes = SE_PRIVILEGE_ENABLED;
+                luidAndAtt.Luid = LD;
+                TP.Privilege = luidAndAtt;
+                retVal = AdjustTokenPrivileges(token, 0, ref TP, 1024, 0, 0);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        public static bool DisablePrivilege(string privilege)
+        {
+            try
+            {
+                int token = 0;
+                int retVal = 0;
+                TOKEN_PRIVILEGE TP = new TOKEN_PRIVILEGE();
+                LUID LD = new LUID();
+                retVal = OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref token);
+                retVal = LookupPrivilegeValue(null, privilege, ref LD);
+                TP.PrivilegeCount = 1;
+                // TP.Attributes should be none (not set) to disable privilege
+                var luidAndAtt = new LUID_AND_ATTRIBUTES();
+                luidAndAtt.Luid = LD;
+                TP.Privilege = luidAndAtt;
+                retVal = AdjustTokenPrivileges(token, 0, ref TP, 1024, 0, 0);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct LUID
+    {
+        internal uint LowPart;
+        internal uint HighPart;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct LUID_AND_ATTRIBUTES
+    {
+        internal LUID Luid;
+        internal uint Attributes;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct TOKEN_PRIVILEGE
+    {
+        internal uint PrivilegeCount;
+        internal LUID_AND_ATTRIBUTES Privilege;
+    }
+    public class TimeZone
+    {
+        public const int ERROR_ACCESS_DENIED = 0x005;
+        public const int CORSEC_E_MISSING_STRONGNAME = -2146233317;
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern bool SetTimeZoneInformation([In] ref TimeZoneInformation lpTimeZoneInformation);
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern bool SetDynamicTimeZoneInformation([In] ref DynamicTimeZoneInformation lpTimeZoneInformation);
+        public static void Set(string name)
+        {
+            var regTimeZones = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Time Zones");
+            // Print out all the possible time-zones.
+            //foreach(var subKey in regTimeZones.GetSubKeyNames())
+            //{
+            //    Console.WriteLine(subKey);
+            //}
+            var subKey = regTimeZones.GetSubKeyNames().Where(s => s == name).First();
+            string daylightName = (string)regTimeZones.OpenSubKey(subKey).GetValue("Dlt");
+            string standardName = (string)regTimeZones.OpenSubKey(subKey).GetValue("Std");
+            byte[] tzi = (byte[])regTimeZones.OpenSubKey(subKey).GetValue("TZI");
+            var regTzi = new RegistryTimeZoneInformation(tzi);
+            TokenPrivilegesAccess.EnablePrivilege("SeTimeZonePrivilege");
+            bool didSet;
+            if (Environment.OSVersion.Version.Major < 6)
+            {
+                var tz = new TimeZoneInformation();
+                tz.Bias = regTzi.Bias;
+                tz.DaylightBias = regTzi.DaylightBias;
+                tz.StandardBias = regTzi.StandardBias;
+                tz.DaylightDate = regTzi.DaylightDate;
+                tz.StandardDate = regTzi.StandardDate;
+                tz.DaylightName = daylightName;
+                tz.StandardName = standardName;
+                didSet = TimeZone.SetTimeZoneInformation(ref tz);
+            }
+            else
+            {
+                var tz = new DynamicTimeZoneInformation();
+                tz.Bias = regTzi.Bias;
+                tz.DaylightBias = regTzi.DaylightBias;
+                tz.StandardBias = regTzi.StandardBias;
+                tz.DaylightDate = regTzi.DaylightDate;
+                tz.StandardDate = regTzi.StandardDate;
+                tz.DaylightName = daylightName;
+                tz.StandardName = standardName;
+                tz.TimeZoneKeyName = subKey;
+                tz.DynamicDaylightTimeDisabled = false;
+                didSet = TimeZone.SetDynamicTimeZoneInformation(ref tz);
+            }
+            int lastError = Marshal.GetLastWin32Error();
+            TokenPrivilegesAccess.DisablePrivilege("SeTimeZonePrivilege");
+            if (! didSet)
+            {
+                if (lastError == TimeZone.ERROR_ACCESS_DENIED)
+                {
+                    throw new SecurityException("Access denied changing System TimeZone.");
+                }
+                else if (lastError == TimeZone.CORSEC_E_MISSING_STRONGNAME)
+                {
+                    throw new SystemException("Application is not signed.");
+                }
+                else
+                {
+                    throw new SystemException("Win32Error: " + lastError + "\nHRESULT: " + Marshal.GetHRForLastWin32Error());
+                }
+            }
+        }
+    }
+}

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/en-us/ComputerManagementDsc.Common.strings.psd1
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.Common/en-us/ComputerManagementDsc.Common.strings.psd1
@@ -12,4 +12,9 @@ ConvertFrom-StringData @'
     NoMatchElementValueMismatchMessage = NOTMATCH: Value [{0}] (type '{1}') for property '{2}' does match. Current state is '{3}' and desired state is '{4}'.
     MatchElementValueMessage           = MATCH: Value [{0}] (type '{1}') for property '{2}' does match. Current state is '{3}' and desired state is '{4}'.
     TestDscParameterResultMessage      = Test-DscParameter result is '{0}'.
+    CurrentTimeZoneMessage             = Current time zone is set to '{0}'
+    GettingTimeZoneCimMessage          = Getting current time zone using {0}.
+    SettingTimeZoneMessage             = Setting time zone to '{0}' using {1}.
+    TimeZoneUpdatedMessage             = Time zone has been updated to '{0}'.
+    AddingSetTimeZoneDotNetTypeMessage = Adding .NET Set time zone Type.
 '@

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.ResourceHelper/ComputerManagementDsc.ResourceHelper.psm1
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.ResourceHelper/ComputerManagementDsc.ResourceHelper.psm1
@@ -167,6 +167,7 @@ function Get-LocalizedData
 }
 
 Export-ModuleMember -Function `
+    Test-Command, `
     Test-IsNanoServer, `
     New-InvalidArgumentException, `
     New-InvalidOperationException, `

--- a/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.ResourceHelper/ComputerManagementDsc.ResourceHelper.psm1
+++ b/Modules/ComputerManagementDsc/Modules/ComputerManagementDsc.ResourceHelper/ComputerManagementDsc.ResourceHelper.psm1
@@ -1,22 +1,5 @@
 <#
     .SYNOPSIS
-    Tests if the specified command can be found.
-
-    .PARAMETER name
-    The name of the command to test.
-#>
-function Test-Command
-{
-    param
-    (
-        [String] $Name
-    )
-
-    return ($null -ne (Get-Command -Name $Name -ErrorAction Continue 2> $null))
-}
-
-<#
-    .SYNOPSIS
     Tests if the current machine is a Nano server.
 #>
 function Test-IsNanoServer
@@ -167,7 +150,6 @@ function Get-LocalizedData
 }
 
 Export-ModuleMember -Function `
-    Test-Command, `
     Test-IsNanoServer, `
     New-InvalidArgumentException, `
     New-InvalidOperationException, `

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The **ComputerManagementDsc** module contains the following resources:
   which is only available on Windows Server 2012/Windows 8 and above. DSC configurations
   containing this resource may be compiled on Windows Server 2008 R2/Windows 7 but
   can not be applied._
+- **TimeZone**: this resource is used for setting the time zone on a machine.
+  It replaces the older standalone `xTimeZone` resource.
 - **VirtualMemory**: allows configuration of properties of the paging file on
   the local computer.
 

--- a/Tests/Integration/MSFT_ScheduledTask.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_ScheduledTask.Integration.Tests.ps1
@@ -149,7 +149,7 @@ try
             It 'Should compile the MOF without throwing in W. Australia Standard Time Timezone' {
                 {
 
-                    Set-TimeZoneId -Id 'W. Australia Standard Time'
+                    Set-TimeZoneId -TimeZoneId 'W. Australia Standard Time'
                     . $currentConfig `
                         -OutputPath $configDir
                 } | Should -Not -Throw
@@ -157,7 +157,7 @@ try
 
             It 'Should apply the MOF correctly in New Zealand Standard Time Timezone' {
                 {
-                    Set-TimeZoneId -Id 'New Zealand Standard Time'
+                    Set-TimeZoneId -TimeZoneId 'New Zealand Standard Time'
                     Start-DscConfiguration `
                         -Path $configDir `
                         -Wait `
@@ -190,7 +190,7 @@ try
             }
 
             AfterAll {
-                Set-TimeZoneId -Id $currentTimeZoneId
+                Set-TimeZoneId -TimeZoneId $currentTimeZoneId
             }
         }
 

--- a/Tests/Integration/MSFT_TimeZone.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_TimeZone.Integration.Tests.ps1
@@ -1,0 +1,83 @@
+$script:DSCModuleName      = 'ComputerManagementDsc'
+$script:DSCResourceName    = 'MSFT_TimeZone'
+
+#region HEADER
+# Integration Test Template Version: 1.1.1
+$script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\ComputerManagementDsc'
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+
+# Store the test machine timezone
+$currentTimeZone = & tzutil.exe /g
+
+# Change the current timezone so that a complete test occurs.
+tzutil.exe /s 'Eastern Standard Time'
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    #region Integration Tests
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $configFile -Verbose -ErrorAction Stop
+
+    Describe "$($script:DSCResourceName)_Integration" {
+        #region DEFAULT TESTS
+        $configData = @{
+            AllNodes = @(
+                @{
+                    NodeName         = 'localhost'
+                    TimeZone         = 'Pacific Standard Time'
+                    IsSingleInstance = 'Yes'
+                }
+            )
+        }
+
+        It 'Should compile and apply the MOF without throwing' {
+            {
+                & "$($script:DSCResourceName)_Config" `
+                    -OutputPath $TestDrive `
+                    -ConfigurationData $configData
+
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+            } | Should Not Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+        }
+        #endregion
+
+        It 'Should have set the configuration and all the parameters should match' {
+            $current = Get-DscConfiguration | Where-Object {
+                $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+            }
+            $current.TimeZone         | Should Be $configData.AllNodes[0].TimeZone
+            $current.IsSingleInstance | Should Be $configData.AllNodes[0].IsSingleInstance
+        }
+    }
+    #endregion
+}
+finally
+{
+    # Restore the test machine timezone
+    & tzutil.exe /s $CurrentTimeZone
+
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/MSFT_TimeZone.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_TimeZone.Integration.Tests.ps1
@@ -54,20 +54,20 @@ try
                     -Verbose `
                     -Force `
                     -ErrorAction Stop
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the configuration and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {
+            $current = Get-DscConfiguration | Where-Object -FilterScript {
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
-            $current.TimeZone         | Should Be $configData.AllNodes[0].TimeZone
-            $current.IsSingleInstance | Should Be $configData.AllNodes[0].IsSingleInstance
+            $current.TimeZone         | Should -Be $configData.AllNodes[0].TimeZone
+            $current.IsSingleInstance | Should -Be $configData.AllNodes[0].IsSingleInstance
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_TimeZone.config.ps1
+++ b/Tests/Integration/MSFT_TimeZone.config.ps1
@@ -1,0 +1,10 @@
+configuration MSFT_TimeZone_Config {
+    Import-DscResource -ModuleName ComputerManagementDsc
+
+    node localhost {
+        TimeZone Integration_Test {
+            TimeZone         = $Node.TimeZone
+            IsSingleInstance = $Node.IsSingleInstance
+        }
+    }
+}

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -81,58 +81,6 @@ function Get-InvalidOperationRecord
     return New-Object @newObjectParams
 }
 
-<#
-    .SYNOPSIS
-        Returns the current Time Zone. This method is used because the
-        Get-TimeZone cmdlet is not available on OS versions prior to
-        Windows 10/Windows Server 2016.
-#>
-function Get-TimeZoneId
-{
-    [CmdletBinding()]
-    param()
-
-    $TimeZone = (Get-CimInstance `
-        -ClassName WIN32_TimeZone `
-        -Namespace root\cimv2).StandardName
-
-    $timeZoneInfo = [System.TimeZoneInfo]::GetSystemTimeZones() |
-        Where-Object StandardName -eq $TimeZone
-
-    return $timeZoneInfo.Id
-} # function Get-TimeZoneId
-
-<#
-    .SYNOPSIS
-        Set the current Time Zone. This method is used because the
-        Set-TimeZone cmdlet is not available on OS versions prior to
-        Windows 10/Windows Server 2016.
-
-    .PARAMETER Id
-        The Id of the TimeZone to set the system to.
-#>
-function Set-TimeZoneId
-{
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $Id
-    )
-
-    try
-    {
-        & tzutil.exe @('/s',$Id)
-    }
-    catch
-    {
-        $ErrorMsg = $_.Exception.Message
-        Write-Verbose -Message $ErrorMsg
-    } # try
-} # function Set-TimeZoneId
-
 Export-ModuleMember -Function `
-    Get-TimeZoneId, `
-    Set-TimeZoneId, `
     Get-InvalidArgumentRecord, `
     Get-InvalidOperationRecord

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -84,7 +84,7 @@ function Get-InvalidOperationRecord
 <#
     .SYNOPSIS
         Returns the current Time Zone. This method is used because the
-        Get-Timezone cmdlet is not available on OS versions prior to
+        Get-TimeZone cmdlet is not available on OS versions prior to
         Windows 10/Windows Server 2016.
 #>
 function Get-TimeZoneId
@@ -93,7 +93,7 @@ function Get-TimeZoneId
     param()
 
     $TimeZone = (Get-CimInstance `
-        -ClassName WIN32_Timezone `
+        -ClassName WIN32_TimeZone `
         -Namespace root\cimv2).StandardName
 
     $timeZoneInfo = [System.TimeZoneInfo]::GetSystemTimeZones() |
@@ -105,11 +105,11 @@ function Get-TimeZoneId
 <#
     .SYNOPSIS
         Set the current Time Zone. This method is used because the
-        Set-Timezone cmdlet is not available on OS versions prior to
+        Set-TimeZone cmdlet is not available on OS versions prior to
         Windows 10/Windows Server 2016.
 
     .PARAMETER Id
-        The Id of the Timezone to set the system to.
+        The Id of the TimeZone to set the system to.
 #>
 function Set-TimeZoneId
 {

--- a/Tests/Unit/ComputerManagementDsc.Common.Tests.ps1
+++ b/Tests/Unit/ComputerManagementDsc.Common.Tests.ps1
@@ -443,9 +443,12 @@ try
 
             Describe 'ComputerManagementDsc.Common\Get-TimeZoneId' {
                 Context '"Get-TimeZone" not available and current timezone is set to "Pacific Standard Time"' {
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Get-TimeZone'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Get-TimeZone'
+                        }
 
                     Mock -CommandName Get-CimInstance -MockWith {
                         @{
@@ -458,18 +461,24 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Get-TimeZone'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Get-TimeZone'
+                            } -Exactly -Times 1
 
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                     }
                 }
 
                 Context '"Get-TimeZone" not available and current timezone is set to "Russia TZ 11 Standard Time"' {
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Get-TimeZone'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Get-TimeZone'
+                        }
 
                     Mock -CommandName Get-CimInstance -MockWith {
                         @{
@@ -482,9 +491,12 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Get-TimeZone'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Get-TimeZone'
+                            } -Exactly -Times 1
 
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
                     }
@@ -495,26 +507,34 @@ try
                     {
                     }
 
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Get-TimeZone'
-                    } -MockWith {
-                        'Get-TimeZone'
-                    }
-
-                    Mock -CommandName Get-TimeZone -MockWith {
-                        @{
-                            StandardName = 'Pacific Standard Time'
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Get-TimeZone'
+                        } -MockWith {
+                            'Get-TimeZone'
                         }
-                    }
+
+                    Mock `
+                        -CommandName Get-TimeZone `
+                        -MockWith {
+                            @{
+                                StandardName = 'Pacific Standard Time'
+                            }
+                        }
 
                     It 'Returns "Pacific Standard Time"' {
                         Get-TimeZoneId | Should -Be 'Pacific Standard Time'
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Get-TimeZone'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Get-TimeZone'
+                            } -Exactly -Times 1
 
                         Assert-MockCalled -CommandName Get-TimeZone -Exactly -Times 1
                     }
@@ -522,7 +542,7 @@ try
             }
 
             Describe 'ComputerManagementDsc.Common\Test-TimezoneId' {
-                Mock Get-TimeZoneId -MockWith {
+                Mock -CommandName Get-TimeZoneId -MockWith {
                     'Russia Time Zone 11'
                 }
 
@@ -541,13 +561,19 @@ try
 
             Describe 'ComputerManagementDsc.Common\Set-TimeZoneId' {
                 Context '"Set-TimeZone" and "Add-Type" is not available, Tzutil Returns 0' {
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Add-Type'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Add-Type'
+                        }
 
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Set-TimeZone'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Set-TimeZone'
+                        }
 
                     Mock -CommandName 'TzUtil.exe' -MockWith {
                         $global:LASTEXITCODE = 0
@@ -561,13 +587,19 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Add-Type'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Add-Type'
+                            } -Exactly -Times 1
 
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Set-TimeZone'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Set-TimeZone'
+                            } -Exactly -Times 1
 
                         Assert-MockCalled -CommandName TzUtil.exe -Exactly -Times 1
                         Assert-MockCalled -CommandName Add-Type -Exactly -Times 0
@@ -575,15 +607,21 @@ try
                 }
 
                 Context '"Set-TimeZone" is not available but "Add-Type" is available' {
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Add-Type'
-                    } -MockWith {
-                        'Add-Type'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Add-Type'
+                        } -MockWith {
+                            'Add-Type'
+                        }
 
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Set-TimeZone'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Set-TimeZone'
+                        }
 
                     Mock -CommandName 'TzUtil.exe' -MockWith {
                         $global:LASTEXITCODE = 0
@@ -598,13 +636,19 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Add-Type'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Add-Type'
+                            } -Exactly -Times 1
 
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Set-TimeZone'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Set-TimeZone'
+                            } -Exactly -Times 1
 
                         Assert-MockCalled -CommandName TzUtil.exe -Exactly -Times 0
                         Assert-MockCalled -CommandName Add-Type -Exactly -Times 0
@@ -622,15 +666,21 @@ try
                         )
                     }
 
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Add-Type'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Add-Type'
+                        }
 
-                    Mock -CommandName Get-Command -ParameterFilter {
-                        $Name -eq 'Set-TimeZone'
-                    } -MockWith {
-                        'Set-TimeZone'
-                    }
+                    Mock `
+                        -CommandName Get-Command `
+                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                        -ParameterFilter {
+                            $Name -eq 'Set-TimeZone'
+                        } -MockWith {
+                            'Set-TimeZone'
+                        }
 
                     Mock -CommandName Set-TimeZone
 
@@ -639,13 +689,19 @@ try
                     }
 
                     It 'Should call expected mocks' {
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Add-Type'
-                        } -Exactly -Times 0
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Add-Type'
+                            } -Exactly -Times 0
 
-                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
-                            $Name -eq 'Set-TimeZone'
-                        } -Exactly -Times 1
+                        Assert-MockCalled `
+                            -CommandName Get-Command `
+                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
+                            -ParameterFilter {
+                                $Name -eq 'Set-TimeZone'
+                            } -Exactly -Times 1
 
                         Assert-MockCalled -CommandName Set-TimeZone -Exactly -Times 1
                     }

--- a/Tests/Unit/ComputerManagementDsc.Common.Tests.ps1
+++ b/Tests/Unit/ComputerManagementDsc.Common.Tests.ps1
@@ -440,6 +440,217 @@ try
                     }
                 }
             }
+
+            Describe 'ComputerManagementDsc.Common\Get-TimeZoneId' {
+                Context '"Get-TimeZone" not available and current timezone is set to "Pacific Standard Time"' {
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Get-TimeZone'
+                    }
+
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        @{
+                            StandardName = 'Pacific Standard Time'
+                        }
+                    }
+
+                    It 'Returns "Pacific Standard Time"' {
+                        Get-TimeZoneId | Should -Be 'Pacific Standard Time'
+                    }
+
+                    It 'Should call expected mocks' {
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Get-TimeZone'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
+                    }
+                }
+
+                Context '"Get-TimeZone" not available and current timezone is set to "Russia TZ 11 Standard Time"' {
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Get-TimeZone'
+                    }
+
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        @{
+                            StandardName = 'Russia TZ 11 Standard Time'
+                        }
+                    }
+
+                    It 'Returns "Russia Time Zone 11"' {
+                        Get-TimeZoneId | Should -Be 'Russia Time Zone 11'
+                    }
+
+                    It 'Should call expected mocks' {
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Get-TimeZone'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1
+                    }
+                }
+
+                Context '"Get-TimeZone" available and current timezone is set to "Pacific Standard Time"' {
+                    function Get-TimeZone
+                    {
+                    }
+
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Get-TimeZone'
+                    } -MockWith {
+                        'Get-TimeZone'
+                    }
+
+                    Mock -CommandName Get-TimeZone -MockWith {
+                        @{
+                            StandardName = 'Pacific Standard Time'
+                        }
+                    }
+
+                    It 'Returns "Pacific Standard Time"' {
+                        Get-TimeZoneId | Should -Be 'Pacific Standard Time'
+                    }
+
+                    It 'Should call expected mocks' {
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Get-TimeZone'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName Get-TimeZone -Exactly -Times 1
+                    }
+                }
+            }
+
+            Describe 'ComputerManagementDsc.Common\Test-TimezoneId' {
+                Mock Get-TimeZoneId -MockWith {
+                    'Russia Time Zone 11'
+                }
+
+                Context 'current timezone matches desired timezone' {
+                    It 'Should return $true' {
+                        Test-TimezoneId -TimeZoneId 'Russia Time Zone 11' | Should -Be $true
+                    }
+                }
+
+                Context 'current timezone does not match desired timezone' {
+                    It 'Should return $false' {
+                        Test-TimezoneId -TimeZoneId 'GMT Standard Time' | Should -Be $false
+                    }
+                }
+            }
+
+            Describe 'ComputerManagementDsc.Common\Set-TimeZoneId' {
+                Context '"Set-TimeZone" and "Add-Type" is not available, Tzutil Returns 0' {
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Add-Type'
+                    }
+
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Set-TimeZone'
+                    }
+
+                    Mock -CommandName 'TzUtil.exe' -MockWith {
+                        $global:LASTEXITCODE = 0
+                        return 'OK'
+                    }
+
+                    Mock -CommandName Add-Type
+
+                    It 'Should not throw an exception' {
+                        { Set-TimeZoneId -TimezoneId 'Eastern Standard Time' } | Should -Not -Throw
+                    }
+
+                    It 'Should call expected mocks' {
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Add-Type'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Set-TimeZone'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName TzUtil.exe -Exactly -Times 1
+                        Assert-MockCalled -CommandName Add-Type -Exactly -Times 0
+                    }
+                }
+
+                Context '"Set-TimeZone" is not available but "Add-Type" is available' {
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Add-Type'
+                    } -MockWith {
+                        'Add-Type'
+                    }
+
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Set-TimeZone'
+                    }
+
+                    Mock -CommandName 'TzUtil.exe' -MockWith {
+                        $global:LASTEXITCODE = 0
+                        return 'OK'
+                    }
+
+                    Mock -CommandName Add-Type
+                    Mock -CommandName Set-TimeZoneUsingDotNet
+
+                    It 'Should not throw an exception' {
+                        { Set-TimeZoneId -TimezoneId 'Eastern Standard Time' } | Should -Not -Throw
+                    }
+
+                    It 'Should call expected mocks' {
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Add-Type'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Set-TimeZone'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName TzUtil.exe -Exactly -Times 0
+                        Assert-MockCalled -CommandName Add-Type -Exactly -Times 0
+                        Assert-MockCalled -CommandName Set-TimeZoneUsingDotNet -Exactly -Times 1
+                    }
+                }
+
+                Context '"Set-TimeZone" is available' {
+                    function Set-TimeZone
+                    {
+                        param
+                        (
+                            [System.String]
+                            $id
+                        )
+                    }
+
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Add-Type'
+                    }
+
+                    Mock -CommandName Get-Command -ParameterFilter {
+                        $Name -eq 'Set-TimeZone'
+                    } -MockWith {
+                        'Set-TimeZone'
+                    }
+
+                    Mock -CommandName Set-TimeZone
+
+                    It 'Should not throw an exception' {
+                        { Set-TimeZoneId -TimezoneId 'Eastern Standard Time' } | Should -Not -Throw
+                    }
+
+                    It 'Should call expected mocks' {
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Add-Type'
+                        } -Exactly -Times 0
+
+                        Assert-MockCalled -CommandName Get-Command -ParameterFilter {
+                            $Name -eq 'Set-TimeZone'
+                        } -Exactly -Times 1
+
+                        Assert-MockCalled -CommandName Set-TimeZone -Exactly -Times 1
+                    }
+                }
+            }
         }
     }
 }

--- a/Tests/Unit/ComputerManagementDsc.Common.Tests.ps1
+++ b/Tests/Unit/ComputerManagementDsc.Common.Tests.ps1
@@ -445,7 +445,6 @@ try
                 Context '"Get-TimeZone" not available and current timezone is set to "Pacific Standard Time"' {
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Get-TimeZone'
                         }
@@ -463,7 +462,6 @@ try
                     It 'Should call expected mocks' {
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Get-TimeZone'
                             } -Exactly -Times 1
@@ -475,7 +473,6 @@ try
                 Context '"Get-TimeZone" not available and current timezone is set to "Russia TZ 11 Standard Time"' {
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Get-TimeZone'
                         }
@@ -493,7 +490,6 @@ try
                     It 'Should call expected mocks' {
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Get-TimeZone'
                             } -Exactly -Times 1
@@ -509,7 +505,6 @@ try
 
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Get-TimeZone'
                         } -MockWith {
@@ -531,7 +526,6 @@ try
                     It 'Should call expected mocks' {
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Get-TimeZone'
                             } -Exactly -Times 1
@@ -563,14 +557,12 @@ try
                 Context '"Set-TimeZone" and "Add-Type" is not available, Tzutil Returns 0' {
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Add-Type'
                         }
 
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Set-TimeZone'
                         }
@@ -589,14 +581,12 @@ try
                     It 'Should call expected mocks' {
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Add-Type'
                             } -Exactly -Times 1
 
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Set-TimeZone'
                             } -Exactly -Times 1
@@ -609,7 +599,6 @@ try
                 Context '"Set-TimeZone" is not available but "Add-Type" is available' {
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Add-Type'
                         } -MockWith {
@@ -618,7 +607,6 @@ try
 
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Set-TimeZone'
                         }
@@ -638,14 +626,12 @@ try
                     It 'Should call expected mocks' {
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Add-Type'
                             } -Exactly -Times 1
 
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Set-TimeZone'
                             } -Exactly -Times 1
@@ -668,14 +654,12 @@ try
 
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Add-Type'
                         }
 
                     Mock `
                         -CommandName Get-Command `
-                        -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                         -ParameterFilter {
                             $Name -eq 'Set-TimeZone'
                         } -MockWith {
@@ -691,14 +675,12 @@ try
                     It 'Should call expected mocks' {
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Add-Type'
                             } -Exactly -Times 0
 
                         Assert-MockCalled `
                             -CommandName Get-Command `
-                            -ModuleName 'ComputerManagementDsc.ResourceHelper' `
                             -ParameterFilter {
                                 $Name -eq 'Set-TimeZone'
                             } -Exactly -Times 1

--- a/Tests/Unit/MSFT_TimeZone.Tests.ps1
+++ b/Tests/Unit/MSFT_TimeZone.Tests.ps1
@@ -1,0 +1,128 @@
+$script:DSCModuleName = 'ComputerManagementDsc'
+$script:DSCResourceName = 'MSFT_TimeZone'
+
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+
+# Unit Test Template Version: 1.2.0
+$script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\ComputerManagementDsc'
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
+
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+    InModuleScope $script:DSCResourceName {
+        $script:DSCResourceName = 'MSFT_TimeZone'
+
+        Describe "$($script:DSCResourceName) MOF single instance schema" {
+            It 'Should have mandatory IsSingleInstance parameter and one other parameter' {
+                $timeZoneResource = Get-DscResource -Name TimeZone
+
+                $timeZoneResource.Properties.Where{
+                    $_.Name -eq 'IsSingleInstance'
+                }.IsMandatory | Should -Be $true
+
+                $timeZoneResource.Properties.Where{
+                    $_.Name -eq 'IsSingleInstance'
+                }.Values | Should -Be 'Yes'
+            }
+        }
+
+        Describe "$($script:DSCResourceName)\Get-TargetResource" {
+            Mock `
+                -CommandName Get-TimeZoneId `
+                -MockWith { 'Pacific Standard Time' }
+
+            $TimeZone = Get-TargetResource `
+                -TimeZone 'Pacific Standard Time' `
+                -IsSingleInstance 'Yes' `
+                -Verbose
+
+            It 'Should return hashtable with Key TimeZone' {
+                $TimeZone.ContainsKey('TimeZone') | Should -Be $true
+            }
+
+            It 'Should return hashtable with Value that matches "Pacific Standard Time"' {
+                $TimeZone.TimeZone = 'Pacific Standard Time'
+            }
+        }
+
+        Describe "$($script:DSCResourceName)\Set-TargetResource" {
+            Mock `
+                -CommandName Set-TimeZoneId
+
+            Mock `
+                -CommandName Get-TimeZoneId `
+                -MockWith { 'Eastern Standard Time' }
+
+            It 'Call Set-TimeZoneId' {
+                Set-TargetResource `
+                    -TimeZone 'Pacific Standard Time' `
+                    -IsSingleInstance 'Yes' `
+                    -Verbose
+
+                Assert-MockCalled `
+                    -CommandName Set-TimeZoneId `
+                    -Exactly 1
+            }
+
+            It 'Should not call Set-TimeZoneId when Current TimeZone already set to desired State' {
+                $SystemTimeZone = Get-TargetResource `
+                    -TimeZone 'Eastern Standard Time' `
+                    -IsSingleInstance 'Yes' `
+                    -Verbose
+
+                Set-TargetResource `
+                    -TimeZone $SystemTimeZone.TimeZone `
+                    -IsSingleInstance 'Yes' `
+                    -Verbose
+
+                Assert-MockCalled `
+                    -CommandName Set-TimeZoneId `
+                    -Scope It `
+                    -Exactly 0
+            }
+        }
+
+        Describe "$($script:DSCResourceName)\Test-TargetResource" {
+            Mock `
+                -ModuleName ComputerManagementDsc.Common `
+                -CommandName Get-TimeZoneId `
+                -MockWith { 'Pacific Standard Time' }
+
+            It 'Should return true when Test is passed Time Zone thats already set' {
+                Test-TargetResource `
+                    -TimeZone 'Pacific Standard Time' `
+                    -IsSingleInstance 'Yes' `
+                    -Verbose | Should -Be $true
+            }
+
+            It 'Should return false when Test is passed Time Zone that is not set' {
+                Test-TargetResource `
+                    -TimeZone 'Eastern Standard Time' `
+                    -IsSingleInstance 'Yes' `
+                    -Verbose | Should -Be $false
+            }
+        }
+    } #end InModuleScope $DSCResourceName
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Unit/MSFT_TimeZone.Tests.ps1
+++ b/Tests/Unit/MSFT_TimeZone.Tests.ps1
@@ -46,17 +46,17 @@ try
                 -CommandName Get-TimeZoneId `
                 -MockWith { 'Pacific Standard Time' }
 
-            $TimeZone = Get-TargetResource `
+            $timeZone = Get-TargetResource `
                 -TimeZone 'Pacific Standard Time' `
                 -IsSingleInstance 'Yes' `
                 -Verbose
 
             It 'Should return hashtable with Key TimeZone' {
-                $TimeZone.ContainsKey('TimeZone') | Should -Be $true
+                $timeZone.ContainsKey('TimeZone') | Should -Be $true
             }
 
             It 'Should return hashtable with Value that matches "Pacific Standard Time"' {
-                $TimeZone.TimeZone = 'Pacific Standard Time'
+                $timeZone.TimeZone = 'Pacific Standard Time'
             }
         }
 
@@ -80,13 +80,13 @@ try
             }
 
             It 'Should not call Set-TimeZoneId when Current TimeZone already set to desired State' {
-                $SystemTimeZone = Get-TargetResource `
+                $systemTimeZone = Get-TargetResource `
                     -TimeZone 'Eastern Standard Time' `
                     -IsSingleInstance 'Yes' `
                     -Verbose
 
                 Set-TargetResource `
-                    -TimeZone $SystemTimeZone.TimeZone `
+                    -TimeZone $systemTimeZone.TimeZone `
                     -IsSingleInstance 'Yes' `
                     -Verbose
 


### PR DESCRIPTION
**Pull Request (PR) description**
This PR moves the xTimeZone resource into this repo and renames it to TimeZone.

**This Pull Request (PR) fixes the following issues:**
- Fixes #157

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - would you mind reviewing this if you get a moment? It is mostly the original xTimeZone, but updated to HQRM.