### PR TITLE
ScheduledTask: IdleWaitTimeout fix & BuiltInAccount added

### DIFF
--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -1,0 +1,53 @@
+@{
+    <#
+        For the custom rules to work, the DscResource.Tests repo must be
+        cloned. It is automatically clone as soon as any unit or
+        integration tests are run.
+    #>
+    CustomRulePath = '.\DSCResource.Tests\DscResource.AnalyzerRules'
+
+    IncludeRules   = @(
+        # DSC Resource Kit style guideline rules.
+        'PSAvoidDefaultValueForMandatoryParameter',
+        'PSAvoidDefaultValueSwitchParameter',
+        'PSAvoidInvokingEmptyMembers',
+        'PSAvoidNullOrEmptyHelpMessageAttribute',
+        'PSAvoidUsingCmdletAliases',
+        'PSAvoidUsingComputerNameHardcoded',
+        'PSAvoidUsingDeprecatedManifestFields',
+        'PSAvoidUsingEmptyCatchBlock',
+        'PSAvoidUsingInvokeExpression',
+        'PSAvoidUsingPositionalParameters',
+        'PSAvoidShouldContinueWithoutForce',
+        'PSAvoidUsingWMICmdlet',
+        'PSAvoidUsingWriteHost',
+        'PSDSCReturnCorrectTypesForDSCFunctions',
+        'PSDSCStandardDSCFunctionsInResource',
+        'PSDSCUseIdenticalMandatoryParametersForDSC',
+        'PSDSCUseIdenticalParametersForDSC',
+        'PSMisleadingBacktick',
+        'PSMissingModuleManifestField',
+        'PSPossibleIncorrectComparisonWithNull',
+        'PSProvideCommentHelp',
+        'PSReservedCmdletChar',
+        'PSReservedParams',
+        'PSUseApprovedVerbs',
+        'PSUseCmdletCorrectly',
+        'PSUseOutputTypeCorrectly',
+        'PSAvoidGlobalVars',
+        'PSAvoidUsingConvertToSecureStringWithPlainText',
+        'PSAvoidUsingPlainTextForPassword',
+        'PSAvoidUsingUsernameAndPasswordParams',
+        'PSDSCUseVerboseMessageInDSCResource',
+        'PSShouldProcess',
+        'PSUseDeclaredVarsMoreThanAssignments',
+        'PSUsePSCredentialType',
+
+        <#
+            This is to test all the DSC Resource Kit custom rules.
+            The name of the function-blocks of each custom rule start
+            with 'Measure*'.
+        #>
+        'Measure-*'
+    )
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     "powershell.codeFormatting.ignoreOneLineBlock": false,
     "powershell.codeFormatting.preset": "Custom",
     "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true
+    "files.insertFinalNewline": true,
+    "powershell.scriptAnalysis.settingsPath": ".vscode\\analyzersettings.psd1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     Valid Values: 'SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE'.
     If set ExecuteAsCredential will be ignored and LogonType will
     be overwritten to 'SericeAccount'.
-    Added Example [14-CreateScheduledTasksAsBuiltinServiceAccount.ps1](Modules/ComputerManagementDsc/Examples/Resources/ScheduledTask/14-CreateScheduledTasksAsBuiltinServiceAccount.ps1).
+    Added Example [16-CreateScheduledTasksAsBuiltinServiceAccount.ps1](Modules/ComputerManagementDsc/Examples/Resources/ScheduledTask/16-CreateScheduledTasksAsBuiltinServiceAccount.ps1).
     The name BuiltInAccount and it's pattern of use is based on
     the property of the same name in the [Service DSCR](https://github.com/PowerShell/PSDscResources#service).
     The reason for defining a new property and not using the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ScheduledTask:
   - Added support for Group Managed Service Accounts, implemented using the ExecuteAsGMSA
     parameter. Fixes [Issue #111](https://github.com/PowerShell/ComputerManagementDsc/issues/111)
+  - Added support to set the Synchronize Across Time Zone option. Fixes [Issue #109](https://github.com/PowerShell/ComputerManagementDsc/issues/109)
 
 ## 5.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,31 @@
 ## Unreleased
 
 - ScheduledTask:
+  - IdleWaitTimeout returned from Get-TargetResource always null - See [Issue #186](https://github.com/PowerShell/ComputerManagementDsc/issues/186).
+  - Added Property BuiltInAccount - See [Issue #130](https://github.com/PowerShell/ComputerManagementDsc/issues/130).
+    Used for running the Scheduled Task as one of the built in
+    service accounts.
+    Valid Values: 'SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE'.
+    If set ExecuteAsCredential will be ignored and LogonType will
+    be overwritten to 'SericeAccount'.
+    Added Example [14-CreateScheduledTasksAsBuiltinServiceAccount.ps1](Modules/ComputerManagementDsc/Examples/Resources/ScheduledTask/14-CreateScheduledTasksAsBuiltinServiceAccount.ps1).
+    The name BuiltInAccount and it's pattern of use is based on
+    the property of the same name in the [Service DSCR](https://github.com/PowerShell/PSDscResources#service).
+    The reason for defining a new property and not using the
+    alternative eg:
+
+    `ExecuteAsCredential = ([pscredential]::new(
+      'NT AUTHORITY\NETWORK SERVICE',
+      (ConvertTo-SecureString -String 'TEST' -AsPlainText -Force)))`
+
+    was the above requires either; the configuration to be compiled
+    with PSDscAllowPlainTextPassword = $true (not secure) or the
+    resultant MOF file to be encrytpted (additional complexity that
+    may not otherwise be required for a specific environment)
   - Added support for Group Managed Service Accounts, implemented using the ExecuteAsGMSA
     parameter. Fixes [Issue #111](https://github.com/PowerShell/ComputerManagementDsc/issues/111)
   - Added support to set the Synchronize Across Time Zone option. Fixes [Issue #109](https://github.com/PowerShell/ComputerManagementDsc/issues/109)
-- Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
+  - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
 
 ## 5.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Added support for Group Managed Service Accounts, implemented using the ExecuteAsGMSA
     parameter. Fixes [Issue #111](https://github.com/PowerShell/ComputerManagementDsc/issues/111)
   - Added support to set the Synchronize Across Time Zone option. Fixes [Issue #109](https://github.com/PowerShell/ComputerManagementDsc/issues/109)
+- Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
 
 ## 5.2.0.0
 

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
@@ -64,6 +64,11 @@ $script:localizedData = Get-LocalizedData `
         The time of day this task should start at - defaults to 12:00 AM. Not valid for
         AtLogon and AtStartup tasks. Not used in Get-TargetResource.
 
+    .PARAMETER SynchronizeAcrossTimeZone
+        Enable the scheduled task option to synchronize across time zones. This is enabled
+        by including the timezone offset in the scheduled task trigger. Defaults to false
+        which does not include the timezone offset.
+
     .PARAMETER Ensure
         Present if the task should exist, Absent if it should be removed.
 
@@ -258,6 +263,10 @@ function Get-TargetResource
         [Parameter()]
         [System.DateTime]
         $StartTime = [System.DateTime]::Today,
+
+        [Parameter()]
+        [System.Boolean]
+        $SynchronizeAcrossTimeZone = $false,
 
         [Parameter()]
         [System.String]
@@ -493,17 +502,20 @@ function Get-TargetResource
 
         if ($startAt)
         {
-            $startAt = [System.DateTime] $startAt
+            $stringSynchronizeAcrossTimeZone = Get-DateTimeString -Date $startAt -SynchronizeAcrossTimeZone $true
+            $returnSynchronizeAcrossTimeZone = $startAt -eq $stringSynchronizeAcrossTimeZone
         }
         else
         {
             $startAt = $StartTime
+            $returnSynchronizeAcrossTimeZone = $false
         }
 
         return @{
             TaskName                        = $task.TaskName
             TaskPath                        = $task.TaskPath
             StartTime                       = $startAt
+            SynchronizeAcrossTimeZone       = $returnSynchronizeAcrossTimeZone
             Ensure                          = 'Present'
             Description                     = $task.Description
             ActionExecutable                = $action.Execute
@@ -580,6 +592,11 @@ function Get-TargetResource
     .PARAMETER StartTime
         The time of day this task should start at - defaults to 12:00 AM. Not valid for
         AtLogon and AtStartup tasks.
+
+    .PARAMETER SynchronizeAcrossTimeZone
+        Enable the scheduled task option to synchronize across time zones. This is enabled
+        by including the timezone offset in the scheduled task trigger. Defaults to false
+        which does not include the timezone offset.
 
     .PARAMETER Ensure
         Present if the task should exist, Absent if it should be removed.
@@ -755,6 +772,10 @@ function Set-TargetResource
         [Parameter()]
         [System.DateTime]
         $StartTime = [System.DateTime]::Today,
+
+        [Parameter()]
+        [System.Boolean]
+        $SynchronizeAcrossTimeZone = $false,
 
         [Parameter()]
         [System.String]
@@ -974,6 +995,12 @@ function Set-TargetResource
             New-InvalidArgumentException `
                 -Message ($script:localizedData.gMSAandCredentialError) `
                 -ArgumentName ExecuteAsGMSA
+        }
+
+        if($SynchronizeAcrossTimeZone -and ($ScheduleType -notin @('Once', 'Daily', 'Weekly'))) {
+            New-InvalidArgumentException `
+                -Message ($script:localizedData.SynchronizeAcrossTimeZoneInvalidScheduleType) `
+                -ArgumentName SynchronizeAcrossTimeZone
         }
 
         # Configure the action
@@ -1304,6 +1331,29 @@ function Set-TargetResource
             $scheduledTask.Description = $Description
         }
 
+        if($scheduledTask.Triggers[0].StartBoundary)
+        {
+            <#
+                The way New-ScheduledTaskTrigger writes the StartBoundary has issues because it does not take
+                the setting "Synchronize across time zones" in consideration. What happens if synchronize across
+                time zone is enabled in the scheduled task GUI is that the time is written like this:
+
+                2018-09-27T18:45:08+02:00
+
+                When the setting synchronize across time zones is disabled, the time is written as:
+
+                2018-09-27T18:45:08
+
+                The problem in New-ScheduledTaskTrigger is that it always writes the time the format that
+                includes the full timezone offset (W2016 behaviour, W2012R2 does it the other way around).
+                Which means "Synchronize across time zones" is enabled by default on W2016 and disabled by
+                default on W2012R2. To prevent that, we are overwriting the StartBoundary here to insert
+                the time in the format we want it, so we can enable or disable "Synchronize across time zones".
+            #>
+
+            $scheduledTask.Triggers[0].StartBoundary = Get-DateTimeString -Date $StartTime -SynchronizeAcrossTimeZone $SynchronizeAcrossTimeZone
+        }
+
         if ($currentValues.Ensure -eq 'Present')
         {
             # Updating the scheduled task
@@ -1364,6 +1414,11 @@ function Set-TargetResource
     .PARAMETER StartTime
         The time of day this task should start at - defaults to 12:00 AM. Not valid for
         AtLogon and AtStartup tasks.
+
+    .PARAMETER SynchronizeAcrossTimeZone
+        Enable the scheduled task option to synchronize across time zones. This is enabled
+        by including the timezone offset in the scheduled task trigger. Defaults to false
+        which does not include the timezone offset.
 
     .PARAMETER Ensure
         Present if the task should exist, Absent if it should be removed.
@@ -1540,6 +1595,10 @@ function Test-TargetResource
         [Parameter()]
         [System.DateTime]
         $StartTime = [System.DateTime]::Today,
+
+        [Parameter()]
+        [System.Boolean]
+        $SynchronizeAcrossTimeZone = $false,
 
         [Parameter()]
         [System.String]
@@ -1744,6 +1803,11 @@ function Test-TargetResource
         $PSBoundParameters['RestartInterval'] = (ConvertTo-TimeSpanFromTimeSpanString -TimeSpanString $RestartInterval).ToString()
     }
 
+    if ($ScheduleType -in @('Once', 'Daily', 'Weekly'))
+    {
+        $PSBoundParameters['StartTime'] = Get-DateTimeString -Date $StartTime -SynchronizeAcrossTimeZone $SynchronizeAcrossTimeZone
+    }
+
     $currentValues = Get-TargetResource @PSBoundParameters
 
     Write-Verbose -Message ($script:localizedData.GetCurrentTaskValuesMessage)
@@ -1943,4 +2007,43 @@ function Disable-ScheduledTask
     $existingTask = Get-ScheduledTask @PSBoundParameters
     $existingTask.Settings.Enabled = $false
     $null = $existingTask | Register-ScheduledTask @PSBoundParameters -Force
+}
+
+<#
+    .SYNOPSIS
+        Returns a formatted datetime string for use in ScheduledTask resource.
+
+    .PARAMETER Date
+        The date to format.
+
+    .PARAMETER SynchronizeAcrossTimeZone
+        Boolean to specifiy if the returned string is formatted in synchronize
+        across time zone format.
+#>
+Function Get-DateTimeString
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.DateTime]
+        $Date,
+
+        [Parameter(Mandatory = $true)]
+        [System.Boolean]
+        $SynchronizeAcrossTimeZone
+    )
+
+    $format = (Get-Culture).DateTimeFormat.SortableDateTimePattern
+
+    if($SynchronizeAcrossTimeZone)
+    {
+        $returnDate = (Get-Date -Date $Date -Format $format) + (Get-Date -Format 'zzz')
+    }
+    else
+    {
+        $returnDate = Get-Date -Date $Date -Format $format
+    }
+
+    return $returnDate
 }

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
@@ -76,6 +76,10 @@ $script:localizedData = Get-LocalizedData `
         True if the task should be enabled, false if it should be disabled.
         Not used in Get-TargetResource.
 
+    .PARAMETER BuiltInAccount
+        Run the task as  one of the built in service accounts ('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE').
+        When set -ExecuteAsCredential will be ignored and -LogonType will be set to 'SericeAccount'
+
     .PARAMETER ExecuteAsCredential
         The credential this task should execute as. If not specified defaults to running
         as the local system account. Cannot be used in combination with ExecuteAsGMSA.
@@ -276,6 +280,10 @@ function Get-TargetResource
         [Parameter()]
         [System.Boolean]
         $Enable = $true,
+
+        [ValidateSet('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE')]
+        [String]
+        $BuiltInAccount,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -511,7 +519,7 @@ function Get-TargetResource
             $returnSynchronizeAcrossTimeZone = $false
         }
 
-        return @{
+        $result = @{
             TaskName                        = $task.TaskName
             TaskPath                        = $task.TaskPath
             StartTime                       = $startAt
@@ -538,7 +546,9 @@ function Get-TargetResource
             AllowStartIfOnBatteries         = -not $settings.DisallowStartIfOnBatteries
             Hidden                          = $settings.Hidden
             RunOnlyIfIdle                   = $settings.RunOnlyIfIdle
-            IdleWaitTimeout                 = ConvertTo-TimeSpanStringFromScheduledTaskString -TimeSpan $settings.IdleSettings.IdleWaitTimeout
+            #$settings.IdleSettings.IdleWaitTimeout is always null, changed to WaitTimeout property to avoid Test-TargetResource returning a spurious value
+            #IdleWaitTimeout                 = ConvertTo-TimeSpanStringFromScheduledTaskString -TimeSpan $settings.IdleSettings.IdleWaitTimeout
+            IdleWaitTimeout                 = ConvertTo-TimeSpanStringFromScheduledTaskString -TimeSpan $settings.IdleSettings.WaitTimeout
             NetworkName                     = $settings.NetworkSettings.Name
             DisallowStartOnRemoteAppSession = $settings.DisallowStartOnRemoteAppSession
             StartWhenAvailable              = $settings.StartWhenAvailable
@@ -558,6 +568,13 @@ function Get-TargetResource
             EventSubscription               = $trigger.Subscription
             Delay                           = ConvertTo-TimeSpanStringFromScheduledTaskString -TimeSpan $trigger.Delay
         }
+
+        if (($result.ContainsKey('LogonType')) -and ($result['LogonType'] -ieq 'ServiceAccount'))
+        {
+            $result.Add('BuiltInAccount', $task.Principal.UserId)
+        }
+
+        return $result
     }
 }
 
@@ -603,6 +620,10 @@ function Get-TargetResource
 
     .PARAMETER Enable
         True if the task should be enabled, false if it should be disabled.
+
+    .PARAMETER BuiltInAccount
+        Run the task as  one of the built in service accounts ('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE').
+        When set -ExecuteAsCredential will be ignored and -LogonType will be set to 'SericeAccount'
 
     .PARAMETER ExecuteAsCredential
         The credential this task should execute as. If not specified defaults to running
@@ -785,6 +806,10 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $Enable = $true,
+
+        [ValidateSet('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE')]
+        [String]
+        $BuiltInAccount,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -990,7 +1015,7 @@ function Set-TargetResource
                 -ArgumentName EventSubscription
         }
 
-        if ($ExecuteAsCredential -and $ExecuteAsGMSA)
+        if ($ExecuteAsGMSA -and ($ExecuteAsCredential -or $BuiltInAccount))
         {
             New-InvalidArgumentException `
                 -Message ($script:localizedData.gMSAandCredentialError) `
@@ -1245,7 +1270,15 @@ function Set-TargetResource
         # Prepare the register arguments
         $registerArguments = @{}
 
-        if ($PSBoundParameters.ContainsKey('ExecuteAsGMSA'))
+        $username = $null
+        if ($PSBoundParameters.ContainsKey('BuiltInAccount'))
+        {
+            #the validateset on BuiltInAccount has already checked the non null value to be 'LOCAL SERVICE', 'NETWORK SERVICE' or 'SYSTEM'
+            $username = 'NT AUTHORITY\' + $BuiltInAccount
+            $registerArguments.Add('User', $username)
+            $LogonType = 'ServiceAccount'
+        }
+        elseif ($PSBoundParameters.ContainsKey('ExecuteAsGMSA'))
         {
             $username = $ExecuteAsGMSA
             $LogonType = 'Password'
@@ -1269,6 +1302,7 @@ function Set-TargetResource
         }
         else
         {
+            #'NT AUTHORITY\SYSTEM' basically gives the schedule task admin privileges, should we default to 'NT AUTHORITY\LOCAL SERVICE' instead?
             $username = 'NT AUTHORITY\SYSTEM'
             $registerArguments.Add('User', $username)
             $LogonType = 'ServiceAccount'
@@ -1425,6 +1459,10 @@ function Set-TargetResource
 
     .PARAMETER Enable
         True if the task should be enabled, false if it should be disabled.
+
+    .PARAMETER BuiltInAccount
+        Run the task as  one of the built in service accounts ('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE').
+        When set -ExecuteAsCredential will be ignored and -LogonType will be set to 'SericeAccount'
 
     .PARAMETER ExecuteAsCredential
         The credential this task should execute as. If not specified defaults to running
@@ -1608,6 +1646,10 @@ function Test-TargetResource
         [Parameter()]
         [System.Boolean]
         $Enable = $true,
+
+        [ValidateSet('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE')]
+        [String]
+        $BuiltInAccount,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -1824,11 +1866,33 @@ function Test-TargetResource
         return $false
     }
 
-    if ($PSBoundParameters.ContainsKey('ExecuteAsCredential'))
+    if ($PSBoundParameters.ContainsKey('BuiltInAccount'))
+    {
+
+        $PSBoundParameters.User = $BuiltInAccount
+        $currentValues.User = $BuiltInAccount
+
+        $PSBoundParameters['LogonType'] = 'ServiceAccount'
+        $currentValues['LogonType'] = 'ServiceAccount'
+    }
+    elseif ($PSBoundParameters.ContainsKey('ExecuteAsCredential'))
     {
         # The password of the execution credential can not be compared
         $username = $ExecuteAsCredential.UserName
         $PSBoundParameters['ExecuteAsCredential'] = $username
+    }
+    else
+    {
+        # must be running as System, login type is ServiceAccount
+        $PSBoundParameters['LogonType'] = 'ServiceAccount'
+        $currentValues['LogonType'] = 'ServiceAccount'
+    }
+
+    if ($PSBoundParameters.ContainsKey('WeeksInterval') -and ((-not $currentValues.ContainsKey('WeeksInterval')) -or ($null -eq $currentValues['WeeksInterval'])))
+    {
+        #The WeeksInterval parameter is defaulted to 1, even when the property is unset/undefined for the current task returned from Get-TargetResouce
+        #initialise a missing or null WeeksInterval to spurious calls to Set-TargetResouce
+        $currentValues.WeeksInterval = $PSBoundParameters['WeeksInterval']
     }
 
     if ($PSBoundParameters.ContainsKey('ExecuteAsGMSA'))
@@ -1848,6 +1912,11 @@ function Test-TargetResource
 
     $desiredValues = $PSBoundParameters
     $desiredValues.TaskPath = $TaskPath
+    if ($desiredValues.ContainsKey('Verbose'))
+    {
+        #initialise a missing or null Verbose to spurious calls to Set-TargetResouce
+        $currentValues.Add('Verbose', $desiredValues['Verbose'])
+    }
 
     Write-Verbose -Message ($script:localizedData.TestingDscParameterStateMessage)
 

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
@@ -970,9 +970,9 @@ function Set-TargetResource
             and the action executable isn't specified then disable the task
         #>
         if ($currentValues.Ensure -eq 'Present' `
-            -and $currentValues.Enable `
-            -and -not $Enable `
-            -and -not $PSBoundParameters.ContainsKey('ActionExecutable'))
+                -and $currentValues.Enable `
+                -and -not $Enable `
+                -and -not $PSBoundParameters.ContainsKey('ActionExecutable'))
         {
             Write-Verbose -Message ($script:localizedData.DisablingExistingScheduledTask -f $TaskName, $TaskPath)
             Disable-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
@@ -1401,8 +1401,8 @@ function Set-TargetResource
 
             # Register the scheduled task
 
-            $registerArguments.Add('TaskName',$TaskName)
-            $registerArguments.Add('TaskPath',$TaskPath)
+            $registerArguments.Add('TaskName', $TaskName)
+            $registerArguments.Add('TaskPath', $TaskPath)
             $registerArguments.Add('InputObject', $scheduledTask)
 
             $null = Register-ScheduledTask @registerArguments

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.schema.mof
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.schema.mof
@@ -13,8 +13,9 @@ class MSFT_ScheduledTask : OMI_BaseResource
     [Write, Description("Enable the scheduled task option to synchronize across time zones. This is enabled by including the timezone offset in the scheduled task trigger. Defaults to false which does not include the timezone offset.")] boolean SynchronizeAcrossTimeZone;
     [Write, Description("Present if the task should exist, Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("True if the task should be enabled, false if it should be disabled")] boolean Enable;
+    [Write, Description("Run the task as  one of the built in service accounts ('SYSTEM', 'LOCAL SERVICE', 'NETWORK SERVICE'). When set -ExecuteAsCredential will be ignored and -LogonType will be set to 'SericeAccount'"), ValueMap{"SYSTEM", "LOCAL SERVICE", "NETWORK SERVICE"}, Values{"SYSTEM", "LOCAL SERVICE", "NETWORK SERVICE"}] string BuiltInAccount;
     [Write, Description("The credential this task should execute as. If not specified defaults to running as the local system account"), EmbeddedInstance("MSFT_Credential")] string ExecuteAsCredential;
-    [Write, Description("The gMSA (Group Managed Service Account) this task should execute as. Cannot be used in combination with ExecuteAsCredential.")] string ExecuteAsGMSA;
+    [Write, Description("The gMSA (Group Managed Service Account) this task should execute as. Cannot be used in combination with ExecuteAsCredential or BuiltInAccount.")] string ExecuteAsGMSA;
     [Write, Description("Specifies the interval between the days in the schedule. An interval of 1 produces a daily schedule. An interval of 2 produces an every-other day schedule.")] Uint32 DaysInterval;
     [Write, Description("Specifies a random amount of time to delay the start time of the trigger. The delay time is a random time between the time the task triggers and the time that you specify in this setting.")] String RandomDelay;
     [Write, Description("Specifies how long the repetition pattern repeats after the task starts. May be set to `Indefinitely` to specify an indefinite duration.")] String RepetitionDuration;

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.schema.mof
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.schema.mof
@@ -10,6 +10,7 @@ class MSFT_ScheduledTask : OMI_BaseResource
     [Write, Description("When should the task be executed"), ValueMap{"Once", "Daily", "Weekly", "AtStartup", "AtLogOn", "OnEvent"}, Values{"Once", "Daily", "Weekly", "AtStartup", "AtLogOn", "OnEvent"}] string ScheduleType;
     [Write, Description("How many units (minutes, hours, days) between each run of this task?")] String RepeatInterval;
     [Write, Description("The time of day this task should start at - defaults to 12:00 AM. Not valid for AtLogon and AtStartup tasks")] DateTime StartTime;
+    [Write, Description("Enable the scheduled task option to synchronize across time zones. This is enabled by including the timezone offset in the scheduled task trigger. Defaults to false which does not include the timezone offset.")] boolean SynchronizeAcrossTimeZone;
     [Write, Description("Present if the task should exist, Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("True if the task should be enabled, false if it should be disabled")] boolean Enable;
     [Write, Description("The credential this task should execute as. If not specified defaults to running as the local system account"), EmbeddedInstance("MSFT_Credential")] string ExecuteAsCredential;

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/en-US/MSFT_ScheduledTask.strings.psd1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/en-US/MSFT_ScheduledTask.strings.psd1
@@ -11,7 +11,7 @@ ConvertFrom-StringData @'
     WeeksIntervalError = WeeksInterval must be greater than zero (0) for Weekly schedules. WeeksInterval specified is '{0}'.
     WeekDayMissingError = At least one weekday must be selected for Weekly schedule.
     OnEventSubscriptionError = No (valid) XML Event Subscription was provided. This is required when the scheduletype is OnEvent.
-    gMSAandCredentialError = Both ExecuteAsGMSA and ExecuteAsCredential parameters have been specified. A task can either run as a gMSA (Group Managed Service Account) or as a custom credential, not both. Please modify your configuration to include just one of the two.
+    gMSAandCredentialError = Both ExecuteAsGMSA and (ExecuteAsCredential or BuiltInAccount) parameters have been specified. A task can run as a gMSA (Group Managed Service Account), a builtin service account or as a custom credential. Please modify your configuration to include just one of the three options.
     SynchronizeAcrossTimeZoneInvalidScheduleType = Setting SynchronizeAcrossTimeZone to true when the ScheduleType is not Once, Daily or Weekly is not a valid configuration. Please keep the default value of false when using other schedule types.
     TriggerCreationError = Error creating new scheduled task trigger.
     ConfigureTriggerRepetitionMessage = Configuring trigger repetition.

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/en-US/MSFT_ScheduledTask.strings.psd1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_ScheduledTask/en-US/MSFT_ScheduledTask.strings.psd1
@@ -12,6 +12,7 @@ ConvertFrom-StringData @'
     WeekDayMissingError = At least one weekday must be selected for Weekly schedule.
     OnEventSubscriptionError = No (valid) XML Event Subscription was provided. This is required when the scheduletype is OnEvent.
     gMSAandCredentialError = Both ExecuteAsGMSA and ExecuteAsCredential parameters have been specified. A task can either run as a gMSA (Group Managed Service Account) or as a custom credential, not both. Please modify your configuration to include just one of the two.
+    SynchronizeAcrossTimeZoneInvalidScheduleType = Setting SynchronizeAcrossTimeZone to true when the ScheduleType is not Once, Daily or Weekly is not a valid configuration. Please keep the default value of false when using other schedule types.
     TriggerCreationError = Error creating new scheduled task trigger.
     ConfigureTriggerRepetitionMessage = Configuring trigger repetition.
     RepetitionIntervalError = Repetition interval is set to '{0}' but repetition duration is '{1}'.

--- a/Modules/ComputerManagementDsc/Examples/Resources/ScheduledTask/15-CreateScheduledTaskOnceSynchronizeAcrossTimeZoneEnabled.ps1
+++ b/Modules/ComputerManagementDsc/Examples/Resources/ScheduledTask/15-CreateScheduledTaskOnceSynchronizeAcrossTimeZoneEnabled.ps1
@@ -1,0 +1,32 @@
+<#
+    .EXAMPLE
+    This example creates a scheduled task called 'Test task sync across time zone enabled'
+    in the folder 'MyTasks' that starts a new powershell process once 2018-10-01 01:00
+    The task will have the option Synchronize across time zone enabled.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DscResource -ModuleName ComputerManagementDsc
+
+    Node $NodeName
+    {
+        ScheduledTask ScheduledTaskOnceSynchronizeAcrossTimeZoneEnabled
+        {
+            TaskName                  = 'Test task sync across time zone enabled'
+            TaskPath                  = '\MyTasks\'
+            ActionExecutable          = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+            ScheduleType              = 'Once'
+            StartTime                 = '2018-10-01T01:00:00'
+            SynchronizeAcrossTimeZone = $true
+            ActionWorkingPath         = (Get-Location).Path
+            Enable                    = $true
+        }
+    }
+}

--- a/Modules/ComputerManagementDsc/Examples/Resources/ScheduledTask/16-CreateScheduledTasksAsBuiltinServiceAccount.ps1
+++ b/Modules/ComputerManagementDsc/Examples/Resources/ScheduledTask/16-CreateScheduledTasksAsBuiltinServiceAccount.ps1
@@ -1,0 +1,34 @@
+<#
+    .EXAMPLE
+    This example creates a scheduled task called 'TriggerOnServiceFailures' in the folder
+    root folder. The task is delayed by exactly 30 seconds each time. The task will run when
+    an error event 7001 of source Service Control Manager is generated in the system log.
+    When a service crashes, it waits for 30 seconds and then starts a new PowerShell instance,
+    in which the file c:\temp\seeme.txt get's created with the value 'Worked!'
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DscResource -ModuleName ComputerManagementDsc
+
+    Node $NodeName
+    {
+        ScheduledTask ServiceEventManager
+        {
+            TaskName = 'TaskRunAsNetworkService'
+            Ensure = 'Present'
+            ActionExecutable = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+            ActionArguments = '-Command Set-Content -Path c:\temp\seeme.txt -Value ''Worked!'''
+            ScheduleType       = 'Once'
+            RepeatInterval     = '00:15:00'
+            RepetitionDuration = '4.00:00:00'
+            BuiltInAccount = 'NETWORK SERVICE'
+        }
+    }
+}

--- a/Tests/Integration/MSFT_ScheduledTask.Config.ps1
+++ b/Tests/Integration/MSFT_ScheduledTask.Config.ps1
@@ -22,6 +22,44 @@ Configuration ScheduledTaskOnceCrossTimezone
     }
 }
 
+Configuration ScheduledTaskOnceSynchronizeAcrossTimeZoneDisabled
+{
+    Import-DscResource -ModuleName ComputerManagementDsc
+    node 'localhost'
+    {
+        ScheduledTask ScheduledTaskOnceSynchronizeAcrossTimeZoneDisabled
+        {
+            TaskName                  = 'Test task sync across time zone disabled'
+            TaskPath                  = '\ComputerManagementDsc\'
+            ActionExecutable          = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+            ScheduleType              = 'Once'
+            StartTime                 = '2018-10-01T01:00:00'
+            SynchronizeAcrossTimeZone = $false
+            ActionWorkingPath         = (Get-Location).Path
+            Enable                    = $true
+        }
+    }
+}
+
+Configuration ScheduledTaskOnceSynchronizeAcrossTimeZoneEnabled
+{
+    Import-DscResource -ModuleName ComputerManagementDsc
+    node 'localhost'
+    {
+        ScheduledTask ScheduledTaskOnceSynchronizeAcrossTimeZoneEnabled
+        {
+            TaskName                  = 'Test task sync across time zone enabled'
+            TaskPath                  = '\ComputerManagementDsc\'
+            ActionExecutable          = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+            ScheduleType              = 'Once'
+            StartTime                 = '2018-10-01T01:00:00'
+            SynchronizeAcrossTimeZone = $true
+            ActionWorkingPath         = (Get-Location).Path
+            Enable                    = $true
+        }
+    }
+}
+
 Configuration ScheduledTaskOnceAdd
 {
     Import-DscResource -ModuleName ComputerManagementDsc

--- a/Tests/Integration/MSFT_ScheduledTask.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_ScheduledTask.Integration.Tests.ps1
@@ -195,6 +195,100 @@ try
             }
         }
 
+        Context "When a scheduled task is created and synchronize across time zone is disabled" {
+            $currentConfig = 'ScheduledTaskOnceSynchronizeAcrossTimeZoneDisabled'
+            $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+            $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+            It 'Should compile the MOF without throwing' {
+                {
+                    . $currentConfig `
+                        -OutputPath $configDir
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF correctly' {
+                {
+                    Start-DscConfiguration `
+                        -Path $configDir `
+                        -Wait `
+                        -Force `
+                        -Verbose `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should return a compliant state after being applied' {
+                (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -Be $true
+            }
+
+            $expectedStartTime = '2018-10-01T01:00:00'
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration    | Where-Object {$_.ConfigurationName -eq $currentConfig}
+                $current.TaskName                  | Should -Be 'Test task sync across time zone disabled'
+                $current.TaskPath                  | Should -Be '\ComputerManagementDsc\'
+                $current.ActionExecutable          | Should -Be 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+                $current.ScheduleType              | Should -Be 'Once'
+                $current.StartTime                 | Should -Be (Get-Date -Date $expectedStartTime)
+                $current.SynchronizeAcrossTimeZone | Should -Be $false
+                $current.ActionWorkingPath         | Should -Be (Get-Location).Path
+                $current.Enable                    | Should -Be $true
+            }
+
+            It "Should have the trigger startBoundary set to $expectedStartTime" {
+                $task = (Get-ScheduledTask -TaskName 'Test task sync across time zone disabled')
+                $task.Triggers[0].StartBoundary | Should -Be $expectedStartTime
+            }
+        }
+
+        Context "When a scheduled task is created and synchronize across time zone is enabled" {
+            $currentConfig = 'ScheduledTaskOnceSynchronizeAcrossTimeZoneEnabled'
+            $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+            $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+            It 'Should compile the MOF without throwing' {
+                {
+                    . $currentConfig `
+                        -OutputPath $configDir
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF correctly' {
+                {
+                    Start-DscConfiguration `
+                        -Path $configDir `
+                        -Wait `
+                        -Force `
+                        -Verbose `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should return a compliant state after being applied' {
+                (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -Be $true
+            }
+
+            $expectedStartTime = '2018-10-01T01:00:00' + (Get-Date -Format 'zzz')
+
+            It 'Should have set the resource and all the parameters should match' {
+                $current = Get-DscConfiguration    | Where-Object {$_.ConfigurationName -eq $currentConfig}
+                $current.TaskName                  | Should -Be 'Test task sync across time zone enabled'
+                $current.TaskPath                  | Should -Be '\ComputerManagementDsc\'
+                $current.ActionExecutable          | Should -Be 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+                $current.ScheduleType              | Should -Be 'Once'
+                $current.StartTime                 | Should -Be (Get-Date -Date $expectedStartTime)
+                $current.SynchronizeAcrossTimeZone | Should -Be $true
+                $current.ActionWorkingPath         | Should -Be (Get-Location).Path
+                $current.Enable                    | Should -Be $true
+            }
+
+            It "Should have the trigger startBoundary set to $expectedStartTime" {
+                $task = (Get-ScheduledTask -TaskName 'Test task sync across time zone enabled')
+                $task.Triggers[0].StartBoundary | Should -Be $expectedStartTime
+            }
+        }
+
         # Simulate a "built-in" scheduled task
         $action = New-ScheduledTaskAction -Execute 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
         $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date)

--- a/Tests/Unit/MSFT_ScheduledTask.Tests.ps1
+++ b/Tests/Unit/MSFT_ScheduledTask.Tests.ps1
@@ -1866,6 +1866,175 @@ try
                     }
                 }
             }
+
+            Context 'When a scheduled task is created and synchronize across time zone is disabled' {
+                $startTimeString           = '2018-10-01T01:00:00'
+                $startTimeStringWithOffset = '2018-10-01T01:00:00' + (Get-Date -Format 'zzz')
+                $testParameters = @{
+                    TaskName                  = 'Test task'
+                    TaskPath                  = '\Test\'
+                    ActionExecutable          = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+                    StartTime                 = Get-Date -Date $startTimeString
+                    SynchronizeAcrossTimeZone = $false
+                    ScheduleType              = 'Once'
+                    Verbose                   = $true
+                }
+
+                Mock -CommandName Get-ScheduledTask -MockWith {
+                    @{
+                        TaskName  = $testParameters.TaskName
+                        TaskPath  = $testParameters.TaskPath
+                        Actions   = @(
+                            [pscustomobject] @{
+                                Execute = $testParameters.ActionExecutable
+                            }
+                        )
+                        Triggers  = @(
+                            [pscustomobject] @{
+                                StartBoundary = $startTimeString
+                                CimClass      = @{
+                                    CimClassName = 'MSFT_TaskTimeTrigger'
+                                }
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return the time in string format and SynchronizeAcrossTimeZone with value false' {
+                    $result = Get-TargetResource @testParameters
+                    $result.StartTime | Should -Be $startTimeString
+                    $result.SynchronizeAcrossTimeZone | Should -Be $false
+                }
+
+                It 'Should return true given that startTime is set correctly' {
+                    Test-TargetResource @testParameters | Should -Be $true
+                }
+
+                Mock -CommandName Get-ScheduledTask -MockWith {
+                    @{
+                        TaskName  = $testParameters.TaskName
+                        TaskPath  = $testParameters.TaskPath
+                        Actions   = @(
+                            [pscustomobject] @{
+                                Execute = $testParameters.ActionExecutable
+                            }
+                        )
+                        Triggers  = @(
+                            [pscustomobject] @{
+                                StartBoundary = $startTimeStringWithOffset
+                                CimClass      = @{
+                                    CimClassName = 'MSFT_TaskTimeTrigger'
+                                }
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return false given that the task is configured with synchronize across time zone' {
+                    Test-TargetResource @testParameters | Should -Be $false
+                }
+
+                Set-TargetResource @testParameters
+
+                It "Should set task trigger StartBoundary to $startTimeString" {
+                    Assert-MockCalled -CommandName Set-ScheduledTask -ParameterFilter {
+                        $InputObject.Triggers[0].StartBoundary -eq $startTimeString
+                    }
+                }
+            }
+
+            Context 'When a scheduled task is created and synchronize across time zone is enabled' {
+                $startTimeString           = '2018-10-01T01:00:00'
+                $startTimeStringWithOffset = '2018-10-01T01:00:00' + (Get-Date -Format 'zzz')
+                $testParameters = @{
+                    TaskName                  = 'Test task'
+                    TaskPath                  = '\Test\'
+                    ActionExecutable          = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+                    StartTime                 = Get-Date -Date $startTimeString
+                    SynchronizeAcrossTimeZone = $true
+                    ScheduleType              = 'Once'
+                    Verbose                   = $true
+                }
+
+                Mock -CommandName Get-ScheduledTask -MockWith {
+                    @{
+                        TaskName  = $testParameters.TaskName
+                        TaskPath  = $testParameters.TaskPath
+                        Actions   = @(
+                            [pscustomobject] @{
+                                Execute = $testParameters.ActionExecutable
+                            }
+                        )
+                        Triggers  = @(
+                            [pscustomobject] @{
+                                StartBoundary = $startTimeStringWithOffset
+                                CimClass      = @{
+                                    CimClassName = 'MSFT_TaskTimeTrigger'
+                                }
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return the time in string format and SynchronizeAcrossTimeZone with value true' {
+                    $result = Get-TargetResource @testParameters
+                    $result.StartTime | Should -Be $startTimeStringWithOffset
+                    $result.SynchronizeAcrossTimeZone | Should -Be $true
+                }
+
+                It 'Should return true given that startTime is set correctly' {
+                    Test-TargetResource @testParameters | Should -Be $true
+                }
+
+                Mock -CommandName Get-ScheduledTask -MockWith {
+                    @{
+                        TaskName  = $testParameters.TaskName
+                        TaskPath  = $testParameters.TaskPath
+                        Actions   = @(
+                            [pscustomobject] @{
+                                Execute = $testParameters.ActionExecutable
+                            }
+                        )
+                        Triggers  = @(
+                            [pscustomobject] @{
+                                StartBoundary = $startTimeString
+                                CimClass      = @{
+                                    CimClassName = 'MSFT_TaskTimeTrigger'
+                                }
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return false given that the task is configured with synchronize across time zone disabled' {
+                    Test-TargetResource @testParameters | Should -Be $false
+                }
+
+                Set-TargetResource @testParameters
+
+                It "Should set task trigger StartBoundary to $startTimeStringWithOffset" {
+                    Assert-MockCalled -CommandName Set-ScheduledTask -ParameterFilter {
+                        $InputObject.Triggers[0].StartBoundary -eq $startTimeStringWithOffset
+                    }
+                }
+            }
+
+            Context 'When a scheduled task is configured to SynchronizeAcrossTimeZone and the ScheduleType is not Once, Daily or Weekly' {
+                $startTimeString              = '2018-10-01T01:00:00'
+                $testParameters = @{
+                    TaskName                  = 'Test task'
+                    TaskPath                  = '\Test\'
+                    ActionExecutable          = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+                    StartTime                 = Get-Date -Date $startTimeString
+                    SynchronizeAcrossTimeZone = $true
+                    ScheduleType              = 'AtLogon'
+                    Verbose                   = $true
+                }
+
+                It 'Should throw when Set-TargetResource is called and SynchronizeAcrossTimeZone is used in combination with an unsupported trigger type' {
+                    { Set-TargetResource @testParamers } | Should Throw
+                }
+            }
         }
     }
     #endregion


### PR DESCRIPTION
#### Pull Request (PR) description
ScheduledTask:
  Fix to IdleWaitTimeout returned from Get-TargetResource always null
  Added BuiltInAccount property to support running task as a builtin account

#### This Pull Request (PR) fixes the following issues
    - Fixes #186 
    - Fixes #130 

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [X] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [X] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/computermanagementdsc/187)
<!-- Reviewable:end -->
