### PR TITLE
BREAKING CHANGE: PowerPlan: Add IsActive read-only property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Added support to set the Synchronize Across Time Zone option. Fixes [Issue #109](https://github.com/PowerShell/ComputerManagementDsc/issues/109)
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
 - PowerPlan:
-  - Added IsActive Read-Only Property. Fixes [Issue #171](https://github.com/PowerShell/ComputerManagementDsc/issues/171)
+  - Added IsActive Read-Only Property - Fixes [Issue #171](https://github.com/PowerShell/ComputerManagementDsc/issues/171).
 
 ## 5.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
 - PowerPlan:
   - Added IsActive Read-Only Property - Fixes [Issue #171](https://github.com/PowerShell/ComputerManagementDsc/issues/171).
-  - InActive power plans are no longer returned with their Name set to null. Now, the name is
-    always returned and the Read-Only property of IsActive is set accordingly.
+  - InActive power plans are no longer returned with their Name set to null.
+    Now, the name is always returned and the Read-Only property of IsActive
+    is set accordingly.
 
 ## 5.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
 - PowerPlan:
   - Added IsActive Read-Only Property - Fixes [Issue #171](https://github.com/PowerShell/ComputerManagementDsc/issues/171).
+  - InActive power plans are no longer returned with their Name set to null.  Now, the name is always returned and the Read-Only property
+    of IsActive is set accordingly.
 
 ## 5.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     parameter. Fixes [Issue #111](https://github.com/PowerShell/ComputerManagementDsc/issues/111)
   - Added support to set the Synchronize Across Time Zone option. Fixes [Issue #109](https://github.com/PowerShell/ComputerManagementDsc/issues/109)
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
+- PowerPlan:
+  - Added IsActive Read-Only Property. Fixes [Issue #171](https://github.com/PowerShell/ComputerManagementDsc/issues/171)
 
 ## 5.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #189](https://github.com/PowerShell/ComputerManagementDsc/issues/189).
 - PowerPlan:
   - Added IsActive Read-Only Property - Fixes [Issue #171](https://github.com/PowerShell/ComputerManagementDsc/issues/171).
-  - InActive power plans are no longer returned with their Name set to null.  Now, the name is always returned and the Read-Only property
-    of IsActive is set accordingly.
+  - InActive power plans are no longer returned with their Name set to null. Now, the name is
+    always returned and the Read-Only property of IsActive is set accordingly.
 
 ## 5.2.0.0
 

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_PowerPlan/MSFT_PowerPlan.psm1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_PowerPlan/MSFT_PowerPlan.psm1
@@ -67,12 +67,10 @@ function Get-TargetResource
         if ($plan.IsActive)
         {
             Write-Verbose -Message ($script:localizedData.PowerPlanIsActive -f $Name)
-            $activePlanName = $Name
         }
         else
         {
             Write-Verbose -Message ($script:localizedData.PowerPlanIsNotActive -f $Name)
-            $activePlanName = $null
         }
     }
     else
@@ -83,7 +81,8 @@ function Get-TargetResource
 
     return @{
         IsSingleInstance = $IsSingleInstance
-        Name             = $activePlanName
+        Name             = $Name
+        IsActive         = $plan.IsActive
     }
 }
 

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_PowerPlan/MSFT_PowerPlan.psm1
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_PowerPlan/MSFT_PowerPlan.psm1
@@ -176,18 +176,11 @@ function Test-TargetResource
         $Name
     )
 
-    $returnValue = $false
-
     Write-Verbose -Message ($script:localizedData.PowerPlanIsBeingValidated -f $Name)
 
     $getTargetResourceResult = Get-TargetResource -IsSingleInstance $IsSingleInstance -Name $Name
 
-    if ($getTargetResourceResult.Name -eq $Name)
-    {
-        $returnValue = $true
-    }
-
-    return $returnValue
+    return $getTargetResourceResult.IsActive
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/Modules/ComputerManagementDsc/DSCResources/MSFT_PowerPlan/MSFT_PowerPlan.schema.mof
+++ b/Modules/ComputerManagementDsc/DSCResources/MSFT_PowerPlan/MSFT_PowerPlan.schema.mof
@@ -3,4 +3,5 @@ class MSFT_PowerPlan : OMI_BaseResource
 {
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
     [Required, Description("The name of the power plan to activate.")] String Name;
+    [Read, Description("Determines if the power plan is active.")] Boolean IsActive;
 };

--- a/Tests/Unit/MSFT_PowerPlan.Tests.ps1
+++ b/Tests/Unit/MSFT_PowerPlan.Tests.ps1
@@ -57,6 +57,7 @@ try
                 $result = Get-TargetResource @testParameters
                 $result.IsSingleInstance | Should -Be 'Yes'
                 $result.Name | Should -Be $testParameters.Name
+                $result.IsActive | Should -Be $true
             }
         }
 
@@ -72,10 +73,11 @@ try
                     -Verifiable
             }
 
-            It 'Should not return any plan name' {
+            It 'Should return an inactive plan' {
                 $result = Get-TargetResource @testParameters
                 $result.IsSingleInstance | Should -Be 'Yes'
-                $result.Name | Should -Be $null
+                $result.Name | Should -Be $testParameters.Name
+                $result.IsActive | Should -Be $false
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Added Read-Only property call IsActive.

#### This Pull Request (PR) fixes the following issues

Fixes #171 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/computermanagementdsc/193)
<!-- Reviewable:end -->
