### PR TITLE
[#248] Get-ScheduledTask calls fix to avoid name clashes with Carbon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Changes to ScheduledTask:
   - Delay property not handled properly on AtLogon and AtStartup trigger - Fixes
     [Issue #230](https://github.com/PowerShell/ComputerManagementDsc/issues/230)
+  - Changed `Get-ScheduledTask` calls to `ScheduledTasks\Get-ScheduledTask` to
+    avoid name clash with `Carbon` module. Fixes [Issue #248](https://github.com/PowerShell/ComputerManagementDsc/issues/248)
 - PendingReboot:
   - Migrated xPendingReboot from [xPendingReboot](https://github.com/PowerShell/xPendingReboot)
     and renamed to PendingReboot.

--- a/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
+++ b/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
@@ -835,7 +835,7 @@ function Set-TargetResource
             Write-Verbose -Message ($script:localizedData.RetrieveScheduledTaskMessage -f $TaskName, $TaskPath)
             $tempScheduledTask = New-ScheduledTask @scheduledTaskArguments -ErrorAction Stop
 
-            $scheduledTask = Get-ScheduledTask `
+            $scheduledTask = ScheduledTasks\Get-ScheduledTask `
                 -TaskName $currentValues.TaskName `
                 -TaskPath $currentValues.TaskPath `
                 -ErrorAction Stop
@@ -1610,7 +1610,7 @@ function Disable-ScheduledTask
         $TaskPath = '\'
     )
 
-    $existingTask = Get-ScheduledTask @PSBoundParameters
+    $existingTask = ScheduledTasks\Get-ScheduledTask @PSBoundParameters
     $existingTask.Settings.Enabled = $false
     $null = $existingTask | Register-ScheduledTask @PSBoundParameters -Force
 }
@@ -1683,7 +1683,7 @@ function Get-CurrentResource
 
     Write-Verbose -Message ($script:localizedData.GettingCurrentTaskValuesMessage -f $TaskName, $TaskPath)
 
-    $task = Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
+    $task = ScheduledTasks\Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
 
     if ($null -eq $task)
     {


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Changes `Get-ScheduledTask` calls to `ScheduledTasks\Get-ScheduledTask` in order to avoid name clash with `Carbon` module

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
- Fixes #248 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/computermanagementdsc/253)
<!-- Reviewable:end -->
