### PR TITLE
WindowsCapability: Fix Set-TargetResource

### DIFF
--- a/DSCResources/MSFT_WindowsCapability/MSFT_WindowsCapability.psm1
+++ b/DSCResources/MSFT_WindowsCapability/MSFT_WindowsCapability.psm1
@@ -102,7 +102,7 @@ function Set-TargetResource
     )
 
     Write-Verbose -Message ($script:localizedData.SetTargetResourceStartMessage -f $Name)
-    $PSBoundParameters.Remove('Ensure')
+    $null = $PSBoundParameters.Remove('Ensure')
     $windowsCapability = Get-WindowsCapability -Online @PSBoundParameters
 
     if ($windowsCapability.State -eq 'Installed')
@@ -124,6 +124,7 @@ function Set-TargetResource
                 $null = Add-WindowsCapability -Online @PSBoundParameters
             }
         }
+
         'Absent'
         {
             if ($Ensure -ne $ensureResult)

--- a/Tests/Unit/MSFT_WindowsCapability.Tests.ps1
+++ b/Tests/Unit/MSFT_WindowsCapability.Tests.ps1
@@ -29,15 +29,11 @@ try
 
         $script:testAndSetTargetResourceParametersPresent = @{
             Name     = $script:testResourceName
-            LogLevel = 'WarningsInfo'
-            LogPath  = Join-Path -Path $ENV:Temp -ChildPath 'Logfile.log'
             Ensure   = 'Present'
         }
 
         $script:testAndSetTargetResourceParametersAbsent = @{
             Name     = $script:testResourceName
-            LogLevel = 'WarningsInfo'
-            LogPath  = Join-Path -Path $ENV:Temp -ChildPath 'Logfile.log'
             Ensure   = 'Absent'
         }
 
@@ -204,7 +200,7 @@ try
 
                 It 'Should not throw an exception' {
                     {
-                        $script:testTargetResourceResult = Set-TargetResource $script:testAndSetTargetResourceParametersAbsent
+                        Set-TargetResource @script:testAndSetTargetResourceParametersAbsent
                     } | Should -Not -Throw
                 }
 
@@ -231,7 +227,7 @@ try
 
                 It 'Should not throw an exception' {
                     {
-                        Set-TargetResource $script:testAndSetTargetResourceParametersPresent
+                        Set-TargetResource @script:testAndSetTargetResourceParametersPresent
                     } | Should -Not -Throw
                 }
 
@@ -256,7 +252,7 @@ try
 
                 It 'Should not throw an exception' {
                     {
-                        Set-TargetResource $script:testAndSetTargetResourceParametersPresent
+                        Set-TargetResource @script:testAndSetTargetResourceParametersPresent
                     } | Should -Not -Throw
                 }
 
@@ -283,7 +279,7 @@ try
 
                 It 'Should not throw an exception' {
                     {
-                        Set-TargetResource $script:testAndSetTargetResourceParametersAbsent
+                        Set-TargetResource @script:testAndSetTargetResourceParametersAbsent
                     } | Should -Not -Throw
                 }
 

--- a/Tests/Unit/MSFT_WindowsCapability.Tests.ps1
+++ b/Tests/Unit/MSFT_WindowsCapability.Tests.ps1
@@ -196,9 +196,9 @@ try
 
             Context 'When a Windows Capability is not enabled' {
                 Mock -CommandName Get-WindowsCapability `
-                -MockWith $getWindowsCapabilityIsNotInstalled `
-                -ModuleName 'MSFT_WindowsCapability' `
-                -Verifiable
+                    -MockWith $getWindowsCapabilityIsNotInstalled `
+                    -ModuleName 'MSFT_WindowsCapability' `
+                    -Verifiable
 
                 Mock -CommandName Add-WindowsCapability -MockWith {}
 
@@ -209,7 +209,9 @@ try
                 }
 
                 It 'Should call Add-WindowsCapability when Ensure set to Present' {
-                    { Set-TargetResource -Name $testResourceName } | Should -Not -Throw
+                    {
+                        Set-TargetResource -Name $testResourceName
+                    } | Should -Not -Throw
                     Assert-MockCalled -CommandName Add-WindowsCapability -Times 1 -Exactly -Scope It
                 }
 
@@ -221,15 +223,15 @@ try
 
             Context 'When a Windows Capability is already enabled' {
                 Mock -CommandName Get-WindowsCapability `
-                -MockWith $getWindowsCapabilityIsInstalled `
-                -ModuleName 'MSFT_WindowsCapability' `
-                -Verifiable
+                    -MockWith $getWindowsCapabilityIsInstalled `
+                    -ModuleName 'MSFT_WindowsCapability' `
+                    -Verifiable
 
                 Mock -CommandName Add-WindowsCapability -MockWith {}
 
                 It 'Should not throw an exception' {
                     {
-                        $script:testTargetResourceResult = Set-TargetResource $script:testAndSetTargetResourceParametersPresent
+                        Set-TargetResource $script:testAndSetTargetResourceParametersPresent
                     } | Should -Not -Throw
                 }
 
@@ -246,20 +248,22 @@ try
 
             Context 'When a Windows Capability is already disabled' {
                 Mock -CommandName Get-WindowsCapability `
-                -MockWith $getWindowsCapabilityIsNotInstalled `
-                -ModuleName 'MSFT_WindowsCapability' `
-                -Verifiable
+                    -MockWith $getWindowsCapabilityIsNotInstalled `
+                    -ModuleName 'MSFT_WindowsCapability' `
+                    -Verifiable
 
                 Mock -CommandName Remove-WindowsCapability -MockWith {}
 
                 It 'Should not throw an exception' {
                     {
-                        $script:testTargetResourceResult = Set-TargetResource $script:testAndSetTargetResourceParametersPresent
+                        Set-TargetResource $script:testAndSetTargetResourceParametersPresent
                     } | Should -Not -Throw
                 }
 
                 It 'Should not call Remove-WindowsCapability when Windows Capability is already disabled' {
-                    { Set-TargetResource -Name $testResourceName } | Should -Not -Throw
+                    {
+                        Set-TargetResource -Name $testResourceName
+                    } | Should -Not -Throw
                     Assert-MockCalled -CommandName Remove-WindowsCapability -Times 0 -Exactly -Scope It
                 }
 
@@ -269,17 +273,17 @@ try
                 }
             }
 
-            Context 'When a Windows Capability is enabled and should not' {
+            Context 'When a Windows Capability is enabled and should not be' {
                 Mock -CommandName Get-WindowsCapability `
-                -MockWith $getWindowsCapabilityIsInstalled `
-                -ModuleName 'MSFT_WindowsCapability' `
-                -Verifiable
+                    -MockWith $getWindowsCapabilityIsInstalled `
+                    -ModuleName 'MSFT_WindowsCapability' `
+                    -Verifiable
 
                 Mock -CommandName Remove-WindowsCapability -MockWith {}
 
                 It 'Should not throw an exception' {
                     {
-                        $script:testTargetResourceResult = Set-TargetResource $script:testAndSetTargetResourceParametersAbsent
+                        Set-TargetResource $script:testAndSetTargetResourceParametersAbsent
                     } | Should -Not -Throw
                 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
The new resource has an issue if you like to disable a Windows Capability.

#### This Pull Request (PR) fixes the following issues
- Fixes an issue with Set-TargetResource 'Absent'
- Add new Unit Tests

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/computermanagementdsc/276)
<!-- Reviewable:end -->
