### PR TITLE
Fix ScheduledTask Description Whitespace issue - Fixes #258

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 ## Unreleased
 
 - ComputerManagementDsc:
-  - Update psd1 description - Fixes [Issue #269](https://github.com/PowerShell/ComputerManagementDsc/issues/269)
+  - Update psd1 description - Fixes [Issue #269](https://github.com/PowerShell/ComputerManagementDsc/issues/269).
 - Fix minor style issues with missing spaces between `param` statements and '('.
 - SmbServerConfiguration:
   - New resource for configuring the SMB Server settings.
   - Added examples for SMB Server Configuration.
 - Minor corrections to CHANGELOG.MD.
+- ScheduledTask:
+  - Fixed bug when description has any form of whitespace at beginning or
+    end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
 
 ## 7.0.0.0
 
@@ -19,11 +22,11 @@
     - Use the ExecuteAsCredential property to pass the username
       The PSCredential needs a non-null that is ignored
   - Delay property not handled properly on AtLogon and AtStartup trigger - Fixes
-    [Issue #230](https://github.com/PowerShell/ComputerManagementDsc/issues/230)
+    [Issue #230](https://github.com/PowerShell/ComputerManagementDsc/issues/230).
   - Changed `Get-ScheduledTask` calls to `ScheduledTasks\Get-ScheduledTask` to
-    avoid name clash with `Carbon` module. Fixes [Issue #248](https://github.com/PowerShell/ComputerManagementDsc/issues/248)
+    avoid name clash with `Carbon` module. Fixes [Issue #248](https://github.com/PowerShell/ComputerManagementDsc/issues/248).
   - Cast `MultipleInstances` value returned by `Get-TargetResource` to `string` -
-    fixes [Issue #255](https://github.com/PowerShell/ComputerManagementDsc/issues/255)
+    fixes [Issue #255](https://github.com/PowerShell/ComputerManagementDsc/issues/255).
 - PendingReboot:
   - Migrated xPendingReboot from [xPendingReboot](https://github.com/PowerShell/xPendingReboot)
     and renamed to PendingReboot.

--- a/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
+++ b/DSCResources/MSFT_ScheduledTask/MSFT_ScheduledTask.psm1
@@ -1448,8 +1448,17 @@ function Test-TargetResource
             format, or we need to remove everything after @ in case
             when the UPN format (User@domain.fqdn) is used.
         #>
-
         $PSBoundParameters['ExecuteAsGMSA'] = $PSBoundParameters.ExecuteAsGMSA -replace '^.+\\|@.+', $null
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description'))
+    {
+        <#
+            All forms of whitespace is automatically trimmed from the description
+            when it is set, so we must not compare it here. See issue #258:
+            https://github.com/PowerShell/ComputerManagementDsc/issues/258
+        #>
+        $PSBoundParameters['Description'] = $PSBoundParameters.Description.Trim()
     }
 
     $desiredValues = $PSBoundParameters


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an issue where the ScheduledTask resource will not go into state if the desired description starts or ends with whitespace chars.

#### This Pull Request (PR) fixes the following issues

- Fixes #258 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing for me when you have time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/computermanagementdsc/279)
<!-- Reviewable:end -->
